### PR TITLE
studio: Fix Celery beat and worker deployments

### DIFF
--- a/studio/templates/deployment-studio-beat.yaml
+++ b/studio/templates/deployment-studio-beat.yaml
@@ -33,6 +33,7 @@ spec:
             {{- toYaml .Values.studioBeat.securityContext | nindent 12 }}
           image: "{{ .Values.studioBackend.image.repository }}:{{ .Values.studioBackend.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.studioBackend.image.pullPolicy }}
+          args: ["/app/bin/run_celery_beat.sh"]
           ports:
             - name: http
               containerPort: 8000

--- a/studio/templates/deployment-studio-worker.yaml
+++ b/studio/templates/deployment-studio-worker.yaml
@@ -33,6 +33,7 @@ spec:
             {{- toYaml .Values.studioWorker.securityContext | nindent 12 }}
           image: "{{ .Values.studioBackend.image.repository }}:{{ .Values.studioBackend.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.studioBackend.image.pullPolicy }}
+          args: ["/app/bin/run_celery_worker.sh"]
           ports:
             - name: http
               containerPort: 8000


### PR DESCRIPTION
The `Deployment` manifests for Celery beat and Celery worker did not contain the correct arguments for the containers. I've updated each of them to reflect the configuration in our development environment.