### PR TITLE
studio: Add container args in backend Deployment

### DIFF
--- a/studio/templates/deployment-studio-backend.yaml
+++ b/studio/templates/deployment-studio-backend.yaml
@@ -33,6 +33,7 @@ spec:
             {{- toYaml .Values.studioBackend.securityContext | nindent 12 }}
           image: "{{ .Values.studioBackend.image.repository }}:{{ .Values.studioBackend.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.studioBackend.image.pullPolicy }}
+          args: ["uwsgi", "--ini", "uwsgi.ini"]
           ports:
             - name: http
               containerPort: 8000


### PR DESCRIPTION
The Studio backend deployment did not contain args for launching uWSGI, so it would only run the database migrations and not launch the web server.