### PR TITLE
studio: Auto-generate secret key for Django

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ $ helm uninstall studio -n <namespace>
 | `global.secrets.postgresDatabasePassword` | PostgreSQL Database Password | `""` | True |
 | `global.secrets.blobVaultAccessKeyId` | Blob Vault (Minio) Access Key ID | `""` | True |
 | `global.secrets.blobVaultSecretAccessId` | Blob Vault (Minio) Secret Access ID | `""` | True |
-| `global.secrets.secretKey` | Secret Key | `""` | True |
+| `global.secrets.secretKey` | Secret Key | `""` | False |
 | `global.configurations.githubUrl` | Github URL | `""` | False |
 | `global.configurations.githubWebhookUrl` | Github Webhook URL | `""` | False |
 | `global.configurations.gitlabUrl` | Gitlab URL | `""` | False |

--- a/studio/templates/secrets.yaml
+++ b/studio/templates/secrets.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: studio
+  annotations:
+    "helm.sh/resource-policy": "keep"
   labels:
     {{- include "studio.labels" . | nindent 4 }}
 type: Opaque
@@ -9,45 +11,65 @@ data:
   {{- if .Values.global.secrets.gitlabClientId }}
   gitlabClientId: {{ .Values.global.secrets.gitlabClientId | b64enc }}
   {{- end }}
+
   {{- if .Values.global.secrets.gitlabSecretKey }}
   gitlabSecretKey: {{ .Values.global.secrets.gitlabSecretKey | b64enc }}
   {{- end }}
+
   {{- if .Values.global.secrets.gitlabWebhookSecret }}
   gitlabWebhookSecret: {{ .Values.global.secrets.gitlabWebhookSecret | b64enc }}
   {{- end }}
+
   {{- if .Values.global.secrets.githubClientId }}
   githubClientId: {{ .Values.global.secrets.githubClientId | b64enc }}
   {{- end }}
+
   {{- if .Values.global.secrets.githubAppId }}
   githubAppId: {{ .Values.global.secrets.githubAppId | b64enc }}
   {{- end }}
+
   {{- if .Values.global.secrets.githubAppSecret }}
   githubAppSecret: {{ .Values.global.secrets.githubAppSecret | b64enc }}
   {{- end }}
+
   {{- if .Values.global.secrets.githubPrivateKey }}
   githubPrivateKey: {{ .Values.global.secrets.githubPrivateKey | b64enc }}
   {{- end }}
+
   {{- if .Values.global.secrets.githubWebhookSecret }}
   githubWebhookSecret: {{ .Values.global.secrets.githubWebhookSecret | b64enc }}
   {{- end }}
+
+  # Set secretKey to existing value or generate a random one
   {{- if .Values.global.secrets.secretKey }}
   secretKey: {{ .Values.global.secrets.secretKey | b64enc }}
+  {{- else }}
+  {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "studio") | default dict }}
+  {{- $secretData := (get $secretObj "data") | default dict }}
+  {{- $secretKey := (get $secretData "secretKey") | default (randAscii 40 | b64enc) }}
+  secretKey: {{ $secretKey | quote }}
   {{- end }}
+  
   {{- if .Values.global.secrets.postgresDatabaseUser }}
   postgresDatabaseUser: {{ .Values.global.secrets.postgresDatabaseUser | b64enc }}
   {{- end }}
+  
   {{- if .Values.global.secrets.postgresDatabasePassword }}
   postgresDatabasePassword: {{ .Values.global.secrets.postgresDatabasePassword | b64enc }}
   {{- end }}
+
   {{- if .Values.global.secrets.blobVaultAccessKeyId }}
   blobVaultAccessKeyId: {{ .Values.global.secrets.blobVaultAccessKeyId | b64enc }}
   {{- end }}
+
   {{- if .Values.global.secrets.blobVaultSecretAccessId }}
   blobVaultSecretAccessId: {{ .Values.global.secrets.blobVaultSecretAccessId | b64enc }}
   {{- end }}
+
   {{- if .Values.global.secrets.bitbucketSecretKey }}
   bitbucketSecretKey: {{ .Values.global.secrets.bitbucketSecretKey | b64enc }}
   {{- end }}
+
   {{- if .Values.global.secrets.bitbucketClientId }}
   bitbucketClientId: {{ .Values.global.secrets.bitbucketClientId | b64enc }}
   {{- end }}

--- a/studio/values.yaml
+++ b/studio/values.yaml
@@ -261,15 +261,13 @@ global:
     githubWebhookSecret: ""
     bitbucketSecretKey: ""
     bitbucketClientId: ""
+    secretKey: ""
     # Mandatory Values
     postgresDatabaseUser: "postgres"
     postgresDatabasePassword: "postgres"
     blobVaultAccessKeyId: "admin"
     blobVaultSecretAccessId: "password"
-    # YOU MUST REGENERATE THE VALUE, https://djecrety.ir/
-    secretKey: "e12s36!=^3$#j$*-3=d=hcb)lbd6)mu($dd%(ql8jq-8a8n=&7"
-
-
+    
   configurations:
     githubUrl: ""
     githubWebhookUrl: ""


### PR DESCRIPTION
The Django secret key is currently hardcoded in `values.yaml`. To prevent re-use, I've changed it so that the secret key gets autogenerated unless provided by the user.

Additionally, I've added `"helm.sh/resource-policy": "keep"` to the `Secret` resource so that existing secrets won't get lost during redeployments.
