### PR TITLE
studio: Add readinessProbe and livenessProbe in Deployments

### DIFF
--- a/studio/templates/deployment-studio-backend.yaml
+++ b/studio/templates/deployment-studio-backend.yaml
@@ -38,14 +38,13 @@ spec:
             - name: http
               containerPort: 8000
               protocol: TCP
-          # livenessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
-          # readinessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
+          readinessProbe:
+            httpGet:
+              path: /health?format=json
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 25
+            timeoutSeconds: 60
           resources:
             {{- toYaml .Values.studioBackend.resources | nindent 12 }}
           env:

--- a/studio/templates/deployment-studio-beat.yaml
+++ b/studio/templates/deployment-studio-beat.yaml
@@ -38,14 +38,6 @@ spec:
             - name: http
               containerPort: 8000
               protocol: TCP
-          # livenessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
-          # readinessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
           resources:
             {{- toYaml .Values.studioBeat.resources | nindent 12 }}
           env:

--- a/studio/templates/deployment-studio-ui.yaml
+++ b/studio/templates/deployment-studio-ui.yaml
@@ -37,14 +37,18 @@ spec:
             - name: http
               containerPort: 3000
               protocol: TCP
-          # livenessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
-          # readinessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
+          livenessProbe:
+            tcpSocket:
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 25
+            timeoutSeconds: 10
           resources:
             {{- toYaml .Values.studioUi.resources | nindent 12 }}
           env:

--- a/studio/templates/deployment-studio-worker.yaml
+++ b/studio/templates/deployment-studio-worker.yaml
@@ -38,14 +38,6 @@ spec:
             - name: http
               containerPort: 8000
               protocol: TCP
-          # livenessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
-          # readinessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
           resources:
             {{- toYaml .Values.studioWorker.resources | nindent 12 }}
           env:


### PR DESCRIPTION
Add `readinessProbe` and `livenessProbe` in relevant Deployments.

Closes https://github.com/iterative/helm-charts/issues/7