### PR TITLE
studio: Always pass SECRET_KEY

### DIFF
--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/studio/templates/_env_vars.tpl
+++ b/charts/studio/templates/_env_vars.tpl
@@ -134,14 +134,10 @@
   value: "psql://{{ .Values.global.secrets.postgresDatabaseUser}}:{{ .Values.global.secrets.postgresDatabasePassword }}@{{ .Values.global.configurations.postgresDatabaseUrl }}"
 
 - name: SECRET_KEY
-{{- if .Values.global.secrets.secretKey }}
   valueFrom:
     secretKeyRef:
       name: studio
       key: secretKey
-{{- else }}
-  value: ""
-{{- end }}
 
 - name: GITHUB_APP_ID
 {{- if .Values.global.secrets.githubAppId }}


### PR DESCRIPTION
The backend API container would not start in cases where the user had the `SECRET_KEY` already stored in a secret. 

With this change, SECRET_KEY is always passed to the container. This is safe, as it will always contain an autogenerated value if the user doesn't provide one.