### PR TITLE
Add support to define CA certificates

### DIFF
--- a/charts/studio/templates/configmap.yaml
+++ b/charts/studio/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: studio
+data:
+  {{- if .Values.global.customCaCert }}
+  self_signed_ca.crt: |
+{{ .Values.global.customCaCert | indent 4}}
+  {{- end }}

--- a/charts/studio/templates/configmap.yaml
+++ b/charts/studio/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: studio
+  name: studio-ca-certificates
 data:
   {{- if .Values.global.customCaCert }}
   self_signed_ca.crt: |

--- a/charts/studio/templates/deployment-studio-backend.yaml
+++ b/charts/studio/templates/deployment-studio-backend.yaml
@@ -48,7 +48,7 @@ spec:
             timeoutSeconds: 60
           {{- if .Values.global.customCaCert }}
           volumeMounts:
-            - name: studio
+            - name: studio-ca-certificates
               mountPath: /usr/local/share/ca-certificates
           {{- end }}
           resources:
@@ -57,9 +57,9 @@ spec:
             {{ include "studio.envvars" . | indent 12 }}
       {{- if .Values.global.customCaCert }}
       volumes:
-        - name: studio
+        - name: studio-ca-certificates
           configMap:
-            name: studio
+            name: studio-ca-certificates
       {{- end }}
       {{- with .Values.studioBackend.nodeSelector }}
       nodeSelector:

--- a/charts/studio/templates/deployment-studio-backend.yaml
+++ b/charts/studio/templates/deployment-studio-backend.yaml
@@ -13,8 +13,9 @@ spec:
       {{- include "studio-backend.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.studioBackend.podAnnotations }}
       annotations:
+        checksum/studio: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- with .Values.studioBackend.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
@@ -33,7 +34,7 @@ spec:
             {{- toYaml .Values.studioBackend.securityContext | nindent 12 }}
           image: "{{ .Values.studioBackend.image.repository }}:{{ .Values.studioBackend.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.studioBackend.image.pullPolicy }}
-          args: ["uwsgi", "--ini", "uwsgi.ini"]
+          args: [ "uwsgi", "--ini", "uwsgi.ini" ]
           ports:
             - name: http
               containerPort: 8000
@@ -45,10 +46,21 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 25
             timeoutSeconds: 60
+          {{- if .Values.global.customCaCert }}
+          volumeMounts:
+            - name: studio
+              mountPath: /usr/local/share/ca-certificates
+          {{- end }}
           resources:
             {{- toYaml .Values.studioBackend.resources | nindent 12 }}
           env:
             {{ include "studio.envvars" . | indent 12 }}
+      {{- if .Values.global.customCaCert }}
+      volumes:
+        - name: studio
+          configMap:
+            name: studio
+      {{- end }}
       {{- with .Values.studioBackend.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/studio/templates/deployment-studio-beat.yaml
+++ b/charts/studio/templates/deployment-studio-beat.yaml
@@ -13,8 +13,9 @@ spec:
       {{- include "studio-beat.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.studioBeat.podAnnotations }}
       annotations:
+        checksum/studio: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- with .Values.studioBeat.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
@@ -46,6 +47,17 @@ spec:
               value: "1"
             - name: "WAIT_FOR_MIGRATIONS"
               value: "1"
+          {{- if .Values.global.customCaCert }}
+          volumeMounts:
+            - name: studio
+              mountPath: /usr/local/share/ca-certificates
+          {{- end }}
+      {{- if .Values.global.customCaCert }}
+      volumes:
+        - name: studio
+          configMap:
+            name: studio
+      {{- end }}
       {{- with .Values.studioBeat.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/studio/templates/deployment-studio-beat.yaml
+++ b/charts/studio/templates/deployment-studio-beat.yaml
@@ -49,14 +49,14 @@ spec:
               value: "1"
           {{- if .Values.global.customCaCert }}
           volumeMounts:
-            - name: studio
+            - name: studio-ca-certificates
               mountPath: /usr/local/share/ca-certificates
           {{- end }}
       {{- if .Values.global.customCaCert }}
       volumes:
-        - name: studio
+        - name: studio-ca-certificates
           configMap:
-            name: studio
+            name: studio-ca-certificates
       {{- end }}
       {{- with .Values.studioBeat.nodeSelector }}
       nodeSelector:

--- a/charts/studio/templates/deployment-studio-ui.yaml
+++ b/charts/studio/templates/deployment-studio-ui.yaml
@@ -54,16 +54,16 @@ spec:
             {{ include "studio.envvars" . | indent 12 }}
           {{- if .Values.global.customCaCert }}
           volumeMounts:
-            - name: studio
+            - name: studio-ca-certificates
               mountPath: /usr/local/share/ca-certificates
           {{- end }}
           resources:
             {{- toYaml .Values.studioUi.resources | nindent 12 }}
       {{- if .Values.global.customCaCert }}
       volumes:
-        - name: studio
+        - name: studio-ca-certificates
           configMap:
-            name: studio
+            name: studio-ca-certificates
       {{- end }}
       {{- with .Values.studioUi.nodeSelector }}
       nodeSelector:

--- a/charts/studio/templates/deployment-studio-ui.yaml
+++ b/charts/studio/templates/deployment-studio-ui.yaml
@@ -13,8 +13,9 @@ spec:
       {{- include "studio-ui.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.studioUi.podAnnotations }}
       annotations:
+        checksum/studio: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- with .Values.studioUi.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
@@ -49,10 +50,21 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 25
             timeoutSeconds: 10
-          resources:
-            {{- toYaml .Values.studioUi.resources | nindent 12 }}
           env:
             {{ include "studio.envvars" . | indent 12 }}
+          {{- if .Values.global.customCaCert }}
+          volumeMounts:
+            - name: studio
+              mountPath: /usr/local/share/ca-certificates
+          {{- end }}
+          resources:
+            {{- toYaml .Values.studioUi.resources | nindent 12 }}
+      {{- if .Values.global.customCaCert }}
+      volumes:
+        - name: studio
+          configMap:
+            name: studio
+      {{- end }}
       {{- with .Values.studioUi.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/studio/templates/deployment-studio-worker.yaml
+++ b/charts/studio/templates/deployment-studio-worker.yaml
@@ -13,8 +13,9 @@ spec:
       {{- include "studio-worker.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.studioWorker.podAnnotations }}
       annotations:
+        checksum/studio: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- with .Values.studioWorker.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
@@ -46,6 +47,17 @@ spec:
               value: "1"
             - name: "WAIT_FOR_MIGRATIONS"
               value: "1"
+          {{- if .Values.global.customCaCert }}
+          volumeMounts:
+            - name: studio
+              mountPath: /usr/local/share/ca-certificates
+          {{- end }}
+      {{- if .Values.global.customCaCert }}
+      volumes:
+        - name: studio
+          configMap:
+            name: studio
+      {{- end }}
       {{- with .Values.studioWorker.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/studio/templates/deployment-studio-worker.yaml
+++ b/charts/studio/templates/deployment-studio-worker.yaml
@@ -49,14 +49,14 @@ spec:
               value: "1"
           {{- if .Values.global.customCaCert }}
           volumeMounts:
-            - name: studio
+            - name: studio-ca-certificates
               mountPath: /usr/local/share/ca-certificates
           {{- end }}
       {{- if .Values.global.customCaCert }}
       volumes:
-        - name: studio
+        - name: studio-ca-certificates
           configMap:
-            name: studio
+            name: studio-ca-certificates
       {{- end }}
       {{- with .Values.studioWorker.nodeSelector }}
       nodeSelector:

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -287,6 +287,10 @@ global:
     maxViews: "100"
     maxTeams: "10"
 
+#  customCaCert: |
+#    -----BEGIN CERTIFICATE-----
+#    ....
+#    -----END CERTIFICATE-----
 
 
 # dependencies


### PR DESCRIPTION
Closes #5 

Allow defining CA certificate, which will be installed in Pod containers. The previous implementation were proposing to bake certificates into a docker image. 

New approach sets internal libraries to use system trust store, OpenSSL (`/etc/ssl/certs`), installed by ca-certificates package, and later updated by update-ca-certificates command executed in `docker-entrypoint.sh`.


Related PR: https://github.com/iterative/studio-selfhosted/pull/19