### PR TITLE
studio: Use app version for the Docker images by default

### DIFF
--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.16.0"
+appVersion: "v1.36.1"
 
 dependencies:
   - name: minio

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -11,7 +11,7 @@ studioUi:
     repository: docker.iterative.ai/viewer_ui
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "latest"
+    # tag: "v1.34.0"
 
   service:
     type: ClusterIP
@@ -83,7 +83,7 @@ studioBackend:
     repository: docker.iterative.ai/viewer_backend
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "latest"
+    # tag: "v1.34.0"
 
   service:
     type: ClusterIP


### PR DESCRIPTION
This change ensures that the Docker images use the app version defined in the Helm chart. 

The `tag: "latest"` example in `values.yaml` was provided so that users may learn about the option, but it shouldn't have been enabled by default.