### PR TITLE
Add release notes template

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,19 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - octocat
+  categories:
+    - title: Breaking changes
+      labels:
+        - breaking-change
+    - title: New features
+      labels:
+        - enhancement
+    - title: Bug fixes
+      labels:
+        - bug
+    - title: Other changes
+      labels:
+        - "*"


### PR DESCRIPTION
Changes:
- Add a release notes template so that we can automatically generate the release notes every time Helm charts are released

Closes https://github.com/iterative/helm-charts/issues/12