### PR TITLE
Generate relese notes with helm-release

### DIFF
--- a/.github/chart-releaser-config.yaml
+++ b/.github/chart-releaser-config.yaml
@@ -1,0 +1,3 @@
+# https://github.com/helm/chart-releaser#config-file
+
+generate-release-notes: true

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -71,6 +71,6 @@ jobs:
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0
         env:
-          CR_SKIP_EXISTING: "false"
           config: .github/chart-releaser-config.yaml
+          CR_SKIP_EXISTING: "false"
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -72,4 +72,5 @@ jobs:
         uses: helm/chart-releaser-action@v1.5.0
         env:
           CR_SKIP_EXISTING: "false"
+          config: .github/chart-releaser-config.yaml
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Reading helm-char releaser I found it uses `cr` tool, which is a Go binary to making releases. It can be configured by [configfile](https://github.com/helm/chart-releaser-action#example-using-custom-config), and one of the [parametes is `--genrate-release-notes`,](https://github.com/helm/chart-releaser#create-github-releases-from-helm-chart-packages) exactly same as `gh release create --generate-release-notes` :-)

