### PR TITLE
README: Fix secret, create namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.tgz
 override.yaml
+.idea

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 ## Install Studio
 
-We'll install studio and related components in a dedicated `studio`namespace. 
+We'll install Studio and related components in a dedicated `studio` namespace. 
 Let's create it now:
 ```bash
 $ kubectl create namespace studio
 ```
 
-> Note: If you want to install studio in any other namespace, modify the
+> Note: If you want to install Studio in any other namespace, modify the
 > `--namespace` flag in the commands below accordingly
 
 Configure Credentials to pull images from our secure registry:

--- a/README.md
+++ b/README.md
@@ -2,13 +2,23 @@
 
 ## Install Studio
 
-Configure Credentials to pull images from secure registry
+We'll install studio and related components in a dedicated `studio`namespace. 
+Let's create it now:
+```bash
+$ kubectl create namespace studio
+```
+
+> Note: If you want to install studio in any other namespace, modify the
+> `--namespace` flag in the commands below accordingly
+
+Configure Credentials to pull images from our secure registry:
 
 ```bash
 $ kubectl create secret docker-registry iterativeai \
+    --namespace studio \
     --docker-server=docker.iterative.ai \
-    --docker-username=username \
-    --docker-password=password
+    --docker-username=<username> \
+    --docker-password=<password>
 ```
 
 Create a file `override.yaml` with the following content or edit `values.yaml`
@@ -22,7 +32,7 @@ Deploy Studio
 
 ```bash
 $ helm repo add iterative https://helm.iterative.ai
-$ helm install studio iterative/studio --create-namespace --namespace studio -f override.yaml
+$ helm install studio iterative/studio --namespace studio -f override.yaml
 ```
 
 ## Update Studio


### PR DESCRIPTION
Now that the charts are installed in `studio` namespace, the `docker-registry` secret needs to be there too (otherwise referencing it the way we do doesn't work, and it should be there anyways).
- creating namespace manually first
- modifying secret creation command
- Adding pycharm metadata dir to gitignore 😃 