### PR TITLE
Saner maxReplicas for studio deployments

### DIFF
--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -169,7 +169,7 @@ studioUi:
   autoscaling:
     enabled: false
     minReplicas: 1
-    maxReplicas: 100
+    maxReplicas: 5
     targetCPUUtilizationPercentage: 80
     # targetMemoryUtilizationPercentage: 80
 
@@ -240,7 +240,7 @@ studioBackend:
   autoscaling:
     enabled: false
     minReplicas: 1
-    maxReplicas: 100
+    maxReplicas: 5
     targetCPUUtilizationPercentage: 80
     # targetMemoryUtilizationPercentage: 80
   
@@ -301,7 +301,7 @@ studioBeat:
   autoscaling:
     enabled: false
     minReplicas: 1
-    maxReplicas: 100
+    maxReplicas: 5
     targetCPUUtilizationPercentage: 80
     # targetMemoryUtilizationPercentage: 80
   
@@ -346,7 +346,7 @@ studioWorker:
   autoscaling:
     enabled: false
     minReplicas: 1
-    maxReplicas: 100
+    maxReplicas: 5
     targetCPUUtilizationPercentage: 80
     # targetMemoryUtilizationPercentage: 80
   


### PR DESCRIPTION
5 is enough for default. 100 is a bit crazy, in case things go wrong, this can overwhelm a small/weak cluster