### PR TITLE
Fixing templating vars inside range context

### DIFF
--- a/charts/studio/templates/_env_vars.tpl
+++ b/charts/studio/templates/_env_vars.tpl
@@ -290,7 +290,7 @@
 {{- if .Values.studioUi.ingress.enabled }}
 {{- range $host := .Values.studioUi.ingress.hosts }}
   {{- range .paths }}
-  value: "studio-ui.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.studioUi.service.port }},studio-backend.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.studioBackend.service.port }},http{{ if $.Values.studioUi.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}"
+  value: "studio-ui.{{ $.Release.Namespace }}.svc.cluster.local:{{ $.Values.studioUi.service.port }},studio-backend.{{ $.Release.Namespace }}.svc.cluster.local:{{ $.Values.studioBackend.service.port }},http{{ if $.Values.studioUi.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}"
   {{- end }}
 {{- end }}
 {{- else }}

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -51,6 +51,9 @@ global:
     github:
       # -- GitHub Enterprise URL
       url: ""
+      # -- GitHub Enterprise API URL
+      apiUrl: ""
+
       # -- GitHub Enterprise OAuth App Client ID
       clientId: ""
       # -- GitHub Enterprise OAuth App ID

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -51,9 +51,6 @@ global:
     github:
       # -- GitHub Enterprise URL
       url: ""
-      # -- GitHub Enterprise API URL
-      apiUrl: ""
-
       # -- GitHub Enterprise OAuth App Client ID
       clientId: ""
       # -- GitHub Enterprise OAuth App ID


### PR DESCRIPTION
Inside `.range` context for vars changes, we need `$` to refer to top level (for `.Release` or `.Values`)

