### PR TITLE
Include GITHUB_API_URL in env vars template

### DIFF
--- a/charts/studio/templates/_env_vars.tpl
+++ b/charts/studio/templates/_env_vars.tpl
@@ -196,6 +196,13 @@
   value: ""
 {{- end }}
 
+- name: GITHUB_API_URL
+{{- if .Values.global.scmProviders.github.apiUrl }}
+  value: {{ .Values.global.scmProviders.github.apiUrl }}
+{{- else }}
+  value: ""
+{{- end }}
+
 - name: GITHUB_WEBHOOK_URL
 {{- if .Values.global.scmProviders.github.webhookUrl }}
   value: {{ .Values.global.scmProviders.github.webhookUrl }}


### PR DESCRIPTION
We forgot to pass `.Values.global.scmProviders.github.apiUrl` as `GITHUB_API_URL` in the environment variables template. This broke the GHE integration.