### PR TITLE
Remove hosts and TLS ranges in Ingress resources

### DIFF
--- a/charts/studio/templates/NOTES.txt
+++ b/charts/studio/templates/NOTES.txt
@@ -1,9 +1,6 @@
 1. Get the application URL by running these commands:
 {{- if .Values.studioUi.ingress.enabled }}
-{{- range $host := .Values.studioUi.ingress.hosts }}
-  {{- range .paths }}
-  http{{ if $.Values.studioUi.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
-  {{- end }}
+  http{{ if $.Values.studioUi.ingress.tlsEnabled }}s{{ end }}://{{ .Values.studioUi.ingress.host }}/
 {{- end }}
 {{- else if contains "NodePort" .Values.studioUi.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "studio.fullname" . }})

--- a/charts/studio/templates/_env_vars.tpl
+++ b/charts/studio/templates/_env_vars.tpl
@@ -4,22 +4,14 @@
 
 - name: API_URL
 {{- if .Values.studioBackend.ingress.enabled }}
-{{- range $host := .Values.studioBackend.ingress.hosts }}
-  {{- range .paths }}
-  value: "http{{ if $.Values.studioBackend.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}"
-  {{- end }}
-{{- end }}
+  value: "http{{ if $.Values.studioBackend.ingress.tlsEnabled }}s{{ end }}://{{ .Values.studioBackend.ingress.host }}/"
 {{- else }}
   value: "http://studio-backend.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.studioBackend.service.port }}"
 {{- end }}
 
 - name: UI_URL
 {{- if .Values.studioUi.ingress.enabled }}
-{{- range $host := .Values.studioUi.ingress.hosts }}
-  {{- range .paths }}
-  value: "http{{ if $.Values.studioUi.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}"
-  {{- end }}
-{{- end }}
+  value: "http{{ if $.Values.studioUi.ingress.tlsEnabled }}s{{ end }}://{{ .Values.studioUi.ingress.host }}/"
 {{- else }}
   value: "http://studio-ui.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.studioUi.service.port }}"
 {{- end }}
@@ -281,11 +273,7 @@
 
 - name: SOCIAL_AUTH_ALLOWED_REDIRECT_HOSTS
 {{- if .Values.studioUi.ingress.enabled }}
-{{- range $host := .Values.studioUi.ingress.hosts }}
-  {{- range .paths }}
-  value: "studio-ui.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.studioUi.service.port }},studio-backend.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.studioBackend.service.port }},http{{ if $.Values.studioUi.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}"
-  {{- end }}
-{{- end }}
+  value: "studio-ui.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.studioUi.service.port }},studio-backend.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.studioBackend.service.port }},http{{ if $.Values.studioUi.ingress.tlsEnabled }}s{{ end }}://{{ .Values.studioUi.ingress.host }}/"
 {{- else }}
   value: "studio-ui.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.studioUi.service.port }},studio-backend.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.studioBackend.service.port }}"
 {{- end }}

--- a/charts/studio/templates/ingress-backend.yaml
+++ b/charts/studio/templates/ingress-backend.yaml
@@ -26,25 +26,19 @@ spec:
   {{- if and .Values.studioBackend.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
   ingressClassName: {{ .Values.studioBackend.ingress.className }}
   {{- end }}
-  {{- if .Values.studioBackend.ingress.tls }}
+  {{- if .Values.studioBackend.ingress.tlsEnabled }}
   tls:
-    {{- range .Values.studioBackend.ingress.tls }}
     - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
+        - {{ .Values.studioBackend.ingress.host | quote }}
+      secretName: {{ .Values.studioBackend.ingress.tlsSecretName }}
   {{- end }}
   rules:
-    {{- range .Values.studioBackend.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ .Values.studioBackend.ingress.host | quote }}
       http:
         paths:
-          {{- range .paths }}
-          - path: {{ .path }}
+          - path: /api
             {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
+            pathType: ImplementationSpecific
             {{- end }}
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
@@ -56,6 +50,4 @@ spec:
               serviceName: studio-backend
               servicePort: {{ $svcPort }}
               {{- end }}
-          {{- end }}
-    {{- end }}
 {{- end }}

--- a/charts/studio/templates/ingress-ui.yaml
+++ b/charts/studio/templates/ingress-ui.yaml
@@ -26,25 +26,19 @@ spec:
   {{- if and .Values.studioUi.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
   ingressClassName: {{ .Values.studioUi.ingress.className }}
   {{- end }}
-  {{- if .Values.studioUi.ingress.tls }}
+  {{- if .Values.studioUi.ingress.tlsEnabled }}
   tls:
-    {{- range .Values.studioUi.ingress.tls }}
     - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
+        - {{ .Values.studioUi.ingress.host | quote }}
+      secretName: {{ .Values.studioUi.ingress.tlsSecretName }}
   {{- end }}
   rules:
-    {{- range .Values.studioUi.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ .Values.studioUi.ingress.host | quote }}
       http:
         paths:
-          {{- range .paths }}
-          - path: {{ .path }}
+          - path: /
             {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
+            pathType: ImplementationSpecific
             {{- end }}
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
@@ -56,6 +50,4 @@ spec:
               serviceName: studio-ui
               servicePort: {{ $svcPort }}
               {{- end }}
-          {{- end }}
-    {{- end }}
 {{- end }}

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -179,15 +179,9 @@ studioUi:
     annotations: {}
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
-    hosts:
-      - host: chart-example.local
-        paths:
-          - path: /
-            pathType: ImplementationSpecific
-    tls: []
-    #  - secretName: chart-example-tls
-    #    hosts:
-    #      - chart-example.local
+    host: chart-example.local
+    tlsEnabled: false
+    tlsSecretName: chart-example-tls
   
   nameOverride: ""
 
@@ -250,15 +244,9 @@ studioBackend:
     annotations: {}
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
-    hosts:
-      - host: chart-example.local
-        paths:
-          - path: /api
-            pathType: ImplementationSpecific
-    tls: []
-    #  - secretName: chart-example-tls
-    #    hosts:
-    #      - chart-example.local
+    host: chart-example.local
+    tlsEnabled: false
+    tlsSecretName: chart-example-tls
   
   nameOverride: ""
 


### PR DESCRIPTION
Changes:
- Remove range for ingress hostname in `studioUi` and `studioBackend`.
- Remove support for setting path prefix in `studioUi` and `studioBackend` ingress.  `studioUi` only supports the `/` path prefix, and `studioBackend` only supports the `/api` prefix
- Remove range for TLS hostnames. This is now set to the hostname defined in `.Values.studioBackend.ingress.host` or `.Values.studioUi.ingress.host`
- Ingress TLS now has to be enabled with `.Values.studioBackend.ingress.tlsEnabled` and `.Values.studioBackend.ingress.tlsEnabled`

Closes https://github.com/iterative/helm-charts/issues/41
