### PR TITLE
Fix SCM_PROVIDERS generation

### DIFF
--- a/charts/studio/templates/_env_vars.tpl
+++ b/charts/studio/templates/_env_vars.tpl
@@ -270,13 +270,13 @@
 
 
 {{- $scmProviders := list }}
-{{- if .Values.global.scmProviders.gitlab.url }}
+{{- if .Values.global.scmProviders.gitlab.enabled }}
 {{- $scmProviders = append $scmProviders "gitlab" }}
 {{- end }}
-{{- if .Values.global.scmProviders.github.url }}
+{{- if .Values.global.scmProviders.github.enabled }}
 {{- $scmProviders = append $scmProviders "github" }}
 {{- end }}
-{{- if .Values.global.scmProviders.bitbucket.url }}
+{{- if .Values.global.scmProviders.bitbucket.enabled }}
 {{- $scmProviders = append $scmProviders "bitbucket" }}
 {{- end }}
 

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -49,26 +49,32 @@ global:
 
   scmProviders:
     github:
-      # -- GitHub Enterprise URL
+      # -- GitHub enabled
+      enabled: false
+
+      # -- GitHub URL
       url: ""
-      # -- GitHub Enterprise API URL
+      # -- GitHub API URL
       apiUrl: ""
 
-      # -- GitHub Enterprise OAuth App Client ID
+      # -- GitHub OAuth App Client ID
       clientId: ""
-      # -- GitHub Enterprise OAuth App ID
+      # -- GitHub OAuth App ID
       appId: ""
-      # -- GitHub Enterprise OAuth App Secret
+      # -- GitHub OAuth App Secret
       appSecret: ""
-      # -- GitHub Enterprise OAuth App Private Key
+      # -- GitHub OAuth App Private Key
       privateKey: ""
 
-      # -- GitHub Enterprise Webhook URL  
+      # -- GitHub Webhook URL  
       webhookUrl: ""
-      # -- GitHub Enterprise Webhook secret
+      # -- GitHub Webhook secret
       webhookSecret: ""
 
     gitlab:
+      # -- GitLab enabled
+      enabled: false
+
       # -- GitLab URL
       url: ""
 
@@ -83,6 +89,9 @@ global:
       webhookSecret: ""
 
     bitbucket:
+      # -- Bitbucket enabled
+      enabled: false
+
       # -- Bitbucket URL
       url: ""
       # -- Bitbucket API URL

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -52,9 +52,11 @@ global:
       # -- GitHub enabled
       enabled: false
 
-      # -- GitHub URL
+      # -- GitHub Enterprise URL
+      # Set this if you're using the selfhosted version
       url: ""
-      # -- GitHub API URL
+      # -- GitHub Enterprise API URL
+      # Set this if you're using the selfhosted version
       apiUrl: ""
 
       # -- GitHub OAuth App Client ID
@@ -75,7 +77,8 @@ global:
       # -- GitLab enabled
       enabled: false
 
-      # -- GitLab URL
+      # -- GitLab Enterprise Edition URL
+      # Set this if you're using the selfhosted version
       url: ""
 
       # -- GitLab OAuth App Client ID
@@ -92,9 +95,11 @@ global:
       # -- Bitbucket enabled
       enabled: false
 
-      # -- Bitbucket URL
+      # -- Bitbucket Server URL
+      # Set this if you're using the selfhosted version
       url: ""
-      # -- Bitbucket API URL
+      # -- Bitbucket Server API URL
+      # Set this if you're using the selfhosted version
       apiUrl: ""
 
       # -- Bitbucket OAuth App Client ID


### PR DESCRIPTION
Currently, we're setting `SCM_PROVIDERS` values when `scmProviders.<provider>.url` variables are defined. The problem with this behavior is that it assumes that the user is using a selfhosted SCM and hence need to overwrite the URL. Some users may want to use the SaaS versions of the SCM providers.

This PR introduces new `enabled` variables for every SCM provider. So, from now on, if you want to use an SCM provider, you must set `enabled` to `true` in its config block.