### PR TITLE
Add enableWebhookSSL setting

### DIFF
--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.9
+version: 0.1.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/studio/templates/_env_vars.tpl
+++ b/charts/studio/templates/_env_vars.tpl
@@ -131,6 +131,13 @@
       name: studio
       key: secretKey
 
+- name: ENABLE_SSL_FOR_WEBHOOK
+{{- if .Values.global.scmProviders.enableWebhookSSL }}
+  value: "True"
+{{- else }}
+  value: "False"
+{{- end }}
+
 - name: GITHUB_APP_ID
 {{- if .Values.global.scmProviders.github.appId }}
   valueFrom:

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -48,6 +48,9 @@ global:
     databasePassword: "postgres"
 
   scmProviders:
+    # Enable SSL for webhooks
+    enableWebhookSSL: true
+
     github:
       # -- GitHub enabled
       enabled: false


### PR DESCRIPTION
Users might want to disable the SCM provider's webhook SSL verification for testing purposes, so I've introduced the `enableWebhookSSL`, which controls this behavior. It's set to false by default, as we don't recommend setting it to true in a production environment.