### PR TITLE
Assortment of fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ imagePullSecrets:
 
 global:
   host: "my-studio.private.com"
+  secretKey: "768d4238-1257-4500-89ce-7ac6aea5c5c9"
   ingress:
     enabled: true
     className: nginx

--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.13
+version: 0.1.14
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/studio/templates/NOTES.txt
+++ b/charts/studio/templates/NOTES.txt
@@ -1,6 +1,6 @@
 1. Get the application URL by running these commands:
 {{- if .Values.global.ingress.enabled }}
-  http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{ .Values.global.url }}/
+  http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{ .Values.global.host }}/
 {{- else if contains "NodePort" .Values.studioUi.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "studio.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")

--- a/charts/studio/templates/NOTES.txt
+++ b/charts/studio/templates/NOTES.txt
@@ -1,6 +1,6 @@
 1. Get the application URL by running these commands:
 {{- if .Values.global.ingress.enabled }}
-  http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{ .Values.global.ingress.host }}/
+  http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{ .Values.global.url }}/
 {{- else if contains "NodePort" .Values.studioUi.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "studio.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")

--- a/charts/studio/templates/NOTES.txt
+++ b/charts/studio/templates/NOTES.txt
@@ -1,4 +1,4 @@
-1. Get the application URL by running these commands:
+Get the application URL by running these commands:
 {{- if .Values.global.ingress.enabled }}
   http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{ .Values.global.host }}/
 {{- else if contains "NodePort" .Values.studioUi.service.type }}

--- a/charts/studio/templates/configmap-studio.yaml
+++ b/charts/studio/templates/configmap-studio.yaml
@@ -4,8 +4,8 @@ metadata:
   name: studio
 data:
   ALLOWED_HOSTS: "*"
-  API_URL: "{{.Values.global.url }}/api"
-  UI_URL: "{{.Values.global.url }}/"
+  API_URL: "http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{.Values.global.host }}/api"
+  UI_URL: "http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{.Values.global.host }}/"
 
   {{- if .Values.global.scmProviders.enableWebhookSSL }}
   ENABLE_SSL_FOR_WEBHOOK: {{ .Values.global.scmProviders.enableWebhookSSL | quote | title }}
@@ -104,7 +104,7 @@ data:
   SOCIAL_AUTH_REDIRECT_IS_HTTPS: "False"
 
   {{- if .Values.global.ingress.enabled }}
-  SOCIAL_AUTH_ALLOWED_REDIRECT_HOSTS: "studio-ui.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.studioUi.service.port }},studio-backend.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.studioBackend.service.port }},{{ .Values.global.url }}/"
+  SOCIAL_AUTH_ALLOWED_REDIRECT_HOSTS: "studio-ui.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.studioUi.service.port }},studio-backend.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.studioBackend.service.port }},{{ .Values.global.host }}/"
   {{- else }}
   SOCIAL_AUTH_ALLOWED_REDIRECT_HOSTS: "studio-ui.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.studioUi.service.port }},studio-backend.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.studioBackend.service.port }}"
   {{- end }}

--- a/charts/studio/templates/configmap-studio.yaml
+++ b/charts/studio/templates/configmap-studio.yaml
@@ -95,7 +95,7 @@ data:
   SOCIAL_AUTH_REDIRECT_IS_HTTPS: "False"
 
   {{- if .Values.global.ingress.enabled }}
-  SOCIAL_AUTH_ALLOWED_REDIRECT_HOSTS: "studio-ui.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.studioUi.service.port }},studio-backend.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.studioBackend.service.port }},{{ .Values.global.ingress.host }}/"
+  SOCIAL_AUTH_ALLOWED_REDIRECT_HOSTS: "studio-ui.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.studioUi.service.port }},studio-backend.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.studioBackend.service.port }},{{ .Values.global.url }}/"
   {{- else }}
   SOCIAL_AUTH_ALLOWED_REDIRECT_HOSTS: "studio-ui.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.studioUi.service.port }},studio-backend.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.studioBackend.service.port }}"
   {{- end }}

--- a/charts/studio/templates/configmap-studio.yaml
+++ b/charts/studio/templates/configmap-studio.yaml
@@ -65,6 +65,15 @@ data:
   {{- if .Values.global.scmProviders.github.webhookUrl }}
   GITHUB_WEBHOOK_URL: {{ .Values.global.scmProviders.github.webhookUrl | quote }}
   {{- end }}
+  {{- if .Values.global.scmProviders.github.clientId }}
+  GITHUB_APP_CLIENT_ID: {{ .Values.global.scmProviders.github.clientId | quote }}
+  {{- end }}
+  {{- if .Values.global.scmProviders.github.appId }}
+  GITHUB_APP_ID: {{ .Values.global.scmProviders.github.appId | quote }}
+  {{- end }}
+  {{- if .Values.global.scmProviders.github.appName }}
+  GITHUB_APP_NAME: {{ .Values.global.scmProviders.github.appName | quote }}
+  {{- end }}
 
   {{- if .Values.global.scmProviders.gitlab.url }}
   GITLAB_URL: {{ .Values.global.scmProviders.gitlab.url | quote}}

--- a/charts/studio/templates/deployment-studio-backend.yaml
+++ b/charts/studio/templates/deployment-studio-backend.yaml
@@ -39,6 +39,13 @@ spec:
             - name: http
               containerPort: 8000
               protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /health?format=json
+              port: 8000
+            initialDelaySeconds: 2
+            periodSeconds: 5
+            timeoutSeconds: 30
           readinessProbe:
             httpGet:
               path: /health?format=json

--- a/charts/studio/templates/ingress-studio.yaml
+++ b/charts/studio/templates/ingress-studio.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.global.ingress.enabled -}}
-{{- $host := regexSplit "//" (.Values.global.url) 2 | last | quote -}}
 {{- if and .Values.global.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.global.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.global.ingress.annotations "kubernetes.io/ingress.class" .Values.global.ingress.className}}
@@ -28,11 +27,11 @@ spec:
   {{- if .Values.global.ingress.tlsEnabled }}
   tls:
     - hosts:
-        - {{ $host }}
+        - {{ .Values.global.host }}
       secretName: {{ .Values.global.ingress.tlsSecretName }}
   {{- end }}
   rules:
-    - host: {{ $host }}
+    - host: {{ .Values.global.host }}
       http:
         paths:
           - path: /

--- a/charts/studio/templates/ingress-studio.yaml
+++ b/charts/studio/templates/ingress-studio.yaml
@@ -49,7 +49,7 @@ spec:
               serviceName: studio-ui
               servicePort: {{ .Values.studioUi.service.port }}
               {{- end }}
-          - path: /api/*
+          - path: /api
             {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
             pathType: ImplementationSpecific
             {{- end }}
@@ -63,7 +63,7 @@ spec:
               serviceName: studio-backend
               servicePort: {{ .Values.studioBackend.service.port }}
               {{- end }}
-          - path: /webhook/*
+          - path: /webhook
             {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
             pathType: ImplementationSpecific
             {{- end }}

--- a/charts/studio/templates/secret-studio.yaml
+++ b/charts/studio/templates/secret-studio.yaml
@@ -22,18 +22,6 @@ stringData:
   GITLAB_WEBHOOK_SECRET: {{ .Values.global.scmProviders.gitlab.webhookSecret | quote }}
   {{- end }}
 
-  {{- if .Values.global.scmProviders.github.clientId }}
-  GITHUB_APP_CLIENT_ID: {{ .Values.global.scmProviders.github.clientId | quote }}
-  {{- end }}
-
-  {{- if .Values.global.scmProviders.github.appId }}
-  GITHUB_APP_ID: {{ .Values.global.scmProviders.github.appId | quote }}
-  {{- end }}
-
-  {{- if .Values.global.scmProviders.github.appName }}
-  GITHUB_APP_NAME: {{ .Values.global.scmProviders.github.appName | quote }}
-  {{- end }}
-
   {{- if .Values.global.scmProviders.github.appSecret }}
   GITHUB_APP_SECRET_KEY: {{ .Values.global.scmProviders.github.appSecret | quote }}
   {{- end }}

--- a/charts/studio/templates/secret-studio.yaml
+++ b/charts/studio/templates/secret-studio.yaml
@@ -30,6 +30,10 @@ stringData:
   GITHUB_APP_ID: {{ .Values.global.scmProviders.github.appId | quote }}
   {{- end }}
 
+  {{- if .Values.global.scmProviders.github.appName }}
+  GITHUB_APP_NAME: {{ .Values.global.scmProviders.github.appName | quote }}
+  {{- end }}
+
   {{- if .Values.global.scmProviders.github.appSecret }}
   GITHUB_APP_SECRET_KEY: {{ .Values.global.scmProviders.github.appSecret | quote }}
   {{- end }}

--- a/charts/studio/templates/secret-studio.yaml
+++ b/charts/studio/templates/secret-studio.yaml
@@ -40,7 +40,7 @@ stringData:
   {{- else }}
   {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "studio") | default dict }}
   {{- $secretData := (get $secretObj "data") | default dict }}
-  {{- $secretKey := ((get $secretData "SECRET_KEY") | b64dec) | default (randAscii 40) }}
+  {{- $secretKey := (get $secretData "SECRET_KEY" | b64dec) | default (randAscii 40) }}
   SECRET_KEY: {{ $secretKey | quote }}
   {{- end }}
 

--- a/charts/studio/templates/secret-studio.yaml
+++ b/charts/studio/templates/secret-studio.yaml
@@ -40,7 +40,7 @@ stringData:
   {{- else }}
   {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "studio") | default dict }}
   {{- $secretData := (get $secretObj "data") | default dict }}
-  {{- $secretKey := (get $secretData "secretKey") | default (randAscii 40) }}
+  {{- $secretKey := ((get $secretData "SECRET_KEY") | b64dec) | default (randAscii 40) }}
   SECRET_KEY: {{ $secretKey | quote }}
   {{- end }}
 

--- a/charts/studio/templates/secret-studio.yaml
+++ b/charts/studio/templates/secret-studio.yaml
@@ -11,27 +11,27 @@ stringData:
   DATABASE_URL: "psql://{{ .Values.global.postgres.databaseUser}}:{{ .Values.global.postgres.databasePassword }}@{{ .Values.global.postgres.databaseUrl }}"
 
   {{- if .Values.global.scmProviders.gitlab.clientId }}
-  GITLAB_CLIENT_ID: {{ .Values.global.scmProviders.gitlab.clientId }}
+  GITLAB_CLIENT_ID: {{ .Values.global.scmProviders.gitlab.clientId | quote }}
   {{- end }}
 
   {{- if .Values.global.scmProviders.gitlab.secretKey }}
-  GITLAB_SECRET_KEY: {{ .Values.global.scmProviders.gitlab.secretKey }}
+  GITLAB_SECRET_KEY: {{ .Values.global.scmProviders.gitlab.secretKey | quote }}
   {{- end }}
 
   {{- if .Values.global.scmProviders.gitlab.webhookSecret }}
-  GITLAB_WEBHOOK_SECRET: {{ .Values.global.scmProviders.gitlab.webhookSecret }}
+  GITLAB_WEBHOOK_SECRET: {{ .Values.global.scmProviders.gitlab.webhookSecret | quote }}
   {{- end }}
 
   {{- if .Values.global.scmProviders.github.clientId }}
-  GITHUB_APP_CLIENT_ID: {{ .Values.global.scmProviders.github.clientId }}
+  GITHUB_APP_CLIENT_ID: {{ .Values.global.scmProviders.github.clientId | quote }}
   {{- end }}
 
   {{- if .Values.global.scmProviders.github.appId }}
-  GITHUB_APP_ID: {{ .Values.global.scmProviders.github.appId }}
+  GITHUB_APP_ID: {{ .Values.global.scmProviders.github.appId | quote }}
   {{- end }}
 
   {{- if .Values.global.scmProviders.github.appSecret }}
-  GITHUB_APP_SECRET_KEY: {{ .Values.global.scmProviders.github.appSecret }}
+  GITHUB_APP_SECRET_KEY: {{ .Values.global.scmProviders.github.appSecret | quote }}
   {{- end }}
 
   {{- if .Values.global.scmProviders.github.privateKey }}
@@ -39,12 +39,12 @@ stringData:
   {{- end }}
 
   {{- if .Values.global.scmProviders.github.webhookSecret }}
-  GITHUB_WEBHOOK_SECRET: {{ .Values.global.scmProviders.github.webhookSecret }}
+  GITHUB_WEBHOOK_SECRET: {{ .Values.global.scmProviders.github.webhookSecret | quote }}
   {{- end }}
 
   # Set secretKey to existing value or generate a random one
   {{- if .Values.global.secretKey }}
-  SECRET_KEY: {{ .Values.global.secretKey }}
+  SECRET_KEY: {{ .Values.global.secretKey | quote }}
   {{- else }}
   {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "studio") | default dict }}
   {{- $secretData := (get $secretObj "data") | default dict }}
@@ -53,17 +53,17 @@ stringData:
   {{- end }}
 
   {{- if .Values.global.blobvault.accessKeyId }}
-  BLOBVAULT_AWS_ACCESS_KEY_ID: {{ .Values.global.blobvault.accessKeyId }}
+  BLOBVAULT_AWS_ACCESS_KEY_ID: {{ .Values.global.blobvault.accessKeyId | quote }}
   {{- end }}
 
   {{- if .Values.global.blobvault.secretAccessKeyId }}
-  BLOBVAULT_AWS_SECRET_ACCESS_ID: {{ .Values.global.blobvault.secretAccessKeyId }}
+  BLOBVAULT_AWS_SECRET_ACCESS_ID: {{ .Values.global.blobvault.secretAccessKeyId | quote }}
   {{- end }}
 
   {{- if .Values.global.scmProviders.bitbucket.secretKey }}
-  BITBUCKET_SECRET_KEY: {{ .Values.global.scmProviders.bitbucket.secretKey }}
+  BITBUCKET_SECRET_KEY: {{ .Values.global.scmProviders.bitbucket.secretKey | quote }}
   {{- end }}
 
   {{- if .Values.global.scmProviders.bitbucket.clientId }}
-  BITBUCKET_CLIENT_ID: {{ .Values.global.scmProviders.bitbucket.clientId }}
+  BITBUCKET_CLIENT_ID: {{ .Values.global.scmProviders.bitbucket.clientId | quote }}
   {{- end }}

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -76,6 +76,8 @@ global:
 
       # -- GitHub OAuth App Client ID
       clientId: ""
+      # -- GitHub OAuth App Name
+      appName: ""
       # -- GitHub OAuth App ID
       appId: ""
       # -- GitHub OAuth App Secret

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -6,7 +6,7 @@
 imagePullSecrets: []
 
 global:
-  # -- Studio: Host app would be accessible on (no http(s) scheme)
+  # -- Studio: Hostname for accessing Studio (no http(s) scheme)
   host: "studio.example.com"
   # -- Studio: Maximum number of views
   maxViews: "100"

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -12,7 +12,8 @@ global:
   maxViews: "100"
   # -- Studio: Maximum number of teams
   maxTeams: "10"
-  # -- Studio: Secret key for encryption
+  # -- Studio: Secret key for signing Webhook payloads
+  # We recommend you set this externally. If left empty, a random key will be generated.
   secretKey: ""
 
   # -- Studio: Custom CA certificate in PEM format

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -85,7 +85,7 @@ global:
       # -- GitHub OAuth App Private Key
       privateKey: ""
 
-      # -- GitHub Webhook URL  
+      # -- GitHub Webhook URL, e.g. <global.url>/webhook/github/
       webhookUrl: ""
       # -- GitHub Webhook secret
       webhookSecret: ""

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -6,8 +6,8 @@
 imagePullSecrets: []
 
 global:
-  # -- Studio: Url
-  url: "http://studio.example.com"
+  # -- Studio: Host app would be accessible on (no http(s) scheme)
+  host: "studio.example.com"
   # -- Studio: Maximum number of views
   maxViews: "100"
   # -- Studio: Maximum number of teams
@@ -85,7 +85,7 @@ global:
       # -- GitHub OAuth App Private Key
       privateKey: ""
 
-      # -- GitHub Webhook URL, e.g. <global.url>/webhook/github/
+      # -- GitHub Webhook URL, e.g. https://<global.host>/webhook/github/
       webhookUrl: ""
       # -- GitHub Webhook secret
       webhookSecret: ""


### PR DESCRIPTION
- ingress path (broken routing, no `*`)
- added missing github app name env var
- broken notes url
- moved from `global.url` to `global.host` (needed in a few places, was broken in `SOCIAL_AUTH_ALLOWED_REDIRECT_AUTH`)
- secrets - adding quoting (now, key `GITHUB_APP_ID` value is a string made of numbers, and encoded by helm wrongly as a number, not a string, so secret creation failed. added this consistently to all values in the secret)
- studio-backend - workaround for stuck initialization race condition (backend comes up before db ready) - by introducing `startupProbe` 🩹  (the time it tries to connect is too short, and it doesn't try to reconnect in the background. that should be fixed in studio)