### PR TITLE
Automatically set GITHUB_API_URL

### DIFF
--- a/charts/studio/templates/configmap-studio.yaml
+++ b/charts/studio/templates/configmap-studio.yaml
@@ -56,11 +56,9 @@ data:
   REDIS_URL: "redis://{{ .Values.redis.fullnameOverride }}-master.{{ .Release.Namespace }}.svc.cluster.local:6379"
   {{- end }}
 
-  {{- if .Values.global.scmProviders.github.apiUrl }}
-  GITHUB_API_URL: {{ .Values.global.scmProviders.github.apiUrl | quote }}
-  {{- end }}
   {{- if .Values.global.scmProviders.github.url }}
   GITHUB_URL: {{ .Values.global.scmProviders.github.url | quote }}
+  GITHUB_API_URL: "{{ .Values.global.scmProviders.github.url | trimSuffix "/" }}/api/v3"
   {{- end }}
   {{- if .Values.global.scmProviders.github.webhookUrl }}
   GITHUB_WEBHOOK_URL: {{ .Values.global.scmProviders.github.webhookUrl | quote }}

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -71,9 +71,6 @@ global:
       # -- GitHub Enterprise URL
       # Set this if you're using the selfhosted version
       url: ""
-      # -- GitHub Enterprise API URL
-      # Set this if you're using the selfhosted version
-      apiUrl: ""
 
       # -- GitHub OAuth App Client ID
       clientId: ""


### PR DESCRIPTION
Currently, users have to set `github.apiUrl` manually and ensure that it ends with an `/api/v3` suffix. 
Since `github.apiUrl `will always be on the same domain as `github.url`, we'll get rid of `github.apiUrl` and automatically set `GITHUB_API_URL` for the users.