### PR TITLE
Add variable for secure flag on session cookies

### DIFF
--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.14
+version: 0.1.15
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/studio/templates/configmap-studio.yaml
+++ b/charts/studio/templates/configmap-studio.yaml
@@ -101,6 +101,8 @@ data:
   {{- end }}
   SCM_PROVIDERS: {{ $scmProviders | join "," | quote }}
 
+  SESSION_COOKIE_SECURE: {{ .Values.global.sessionCookieSecure | quote | title }}
+
   SOCIAL_AUTH_REDIRECT_IS_HTTPS: "False"
 
   {{- if .Values.global.ingress.enabled }}

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -16,6 +16,9 @@ global:
   # We recommend you set this externally. If left empty, a random key will be generated.
   secretKey: ""
 
+  # -- Studio: Enable secure flag on session cookies
+  sessionCookieSecure: true
+
   # -- Studio: Custom CA certificate in PEM format
   # customCaCert: |-
   #   -----BEGIN CERTIFICATE-----


### PR DESCRIPTION
If Studio is deployed on a domain without TLS, we shouldn't mark the session cookies as secure. Otherwise, SCM provider authentication flow breaks.

Studio already has a flag, `SESSION_COOKIE_SECURE` (True by default), which controls this behavior. However, it was not exposed as a variable in the Helm chart.