### PR TITLE
Rename github appSecret variable to clientSecret

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ global:
       appId: "<app-id>"
       appName: "iterative-studio-selfhosted"
       clientId: "<gh-client-id>"
-      appSecret: "<gh-app-secret>"
+      clientSecret: "<gh-app-secret>"
       webhookUrl: "https://my-studio.private.com/webhook/github"
       privateKey: |-
         -----BEGIN RSA PRIVATE KEY-----

--- a/charts/studio/templates/secret-studio.yaml
+++ b/charts/studio/templates/secret-studio.yaml
@@ -22,8 +22,8 @@ stringData:
   GITLAB_WEBHOOK_SECRET: {{ .Values.global.scmProviders.gitlab.webhookSecret | quote }}
   {{- end }}
 
-  {{- if .Values.global.scmProviders.github.appSecret }}
-  GITHUB_APP_SECRET_KEY: {{ .Values.global.scmProviders.github.appSecret | quote }}
+  {{- if .Values.global.scmProviders.github.clientSecret }}
+  GITHUB_APP_SECRET_KEY: {{ .Values.global.scmProviders.github.clientSecret | quote }}
   {{- end }}
 
   {{- if .Values.global.scmProviders.github.privateKey }}

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -78,14 +78,15 @@ global:
       # Set this if you're using the selfhosted version
       apiUrl: ""
 
-      # -- GitHub OAuth App Client ID
-      clientId: ""
+
       # -- GitHub OAuth App Name
       appName: ""
       # -- GitHub OAuth App ID
       appId: ""
+      # -- GitHub OAuth App Client ID
+      clientId: ""
       # -- GitHub OAuth App Secret
-      appSecret: ""
+      clientSecret: ""
       # -- GitHub OAuth App Private Key
       privateKey: ""
 


### PR DESCRIPTION
This change renames the `global.scmProviders.github.appSecret` variable to `global.scmProviders.github.clientSecret` in order to reflect the terminology used by GitHub.