### PR TITLE
Remove deprecated GITHUB_WEBHOOK_SECRET env variable

### DIFF
--- a/charts/studio/templates/secret-studio.yaml
+++ b/charts/studio/templates/secret-studio.yaml
@@ -30,10 +30,6 @@ stringData:
   GITHUB_APP_PRIVATE_KEY_PEM: |- {{ .Values.global.scmProviders.github.privateKey | nindent 4 }}
   {{- end }}
 
-  {{- if .Values.global.scmProviders.github.webhookSecret }}
-  GITHUB_WEBHOOK_SECRET: {{ .Values.global.scmProviders.github.webhookSecret | quote }}
-  {{- end }}
-
   # Set secretKey to existing value or generate a random one
   {{- if .Values.global.secretKey }}
   SECRET_KEY: {{ .Values.global.secretKey | quote }}

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -91,8 +91,6 @@ global:
 
       # -- GitHub Webhook URL, e.g. https://<global.host>/webhook/github/
       webhookUrl: ""
-      # -- GitHub Webhook secret
-      webhookSecret: ""
 
     gitlab:
       # -- GitLab enabled


### PR DESCRIPTION
The `GITHUB_WEBHOOK_SECRET` is deprecated in Studio, so let's remove it from the Helm chart.