### PR TITLE
Remove condition for ENABLE_SSL_FOR_WEBHOOK

### DIFF
--- a/charts/studio/templates/configmap-studio.yaml
+++ b/charts/studio/templates/configmap-studio.yaml
@@ -7,9 +7,7 @@ data:
   API_URL: "http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{.Values.global.host }}/api"
   UI_URL: "http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{.Values.global.host }}/"
 
-  {{- if .Values.global.scmProviders.enableWebhookSSL }}
   ENABLE_SSL_FOR_WEBHOOK: {{ .Values.global.scmProviders.enableWebhookSSL | quote | title }}
-  {{- end }}
 
   {{- if .Values.global.scmProviders.bitbucket.url }}
   BITBUCKET_URL: {{.Values.global.scmProviders.bitbucket.url | quote }}


### PR DESCRIPTION
Studio by default sets `ENABLE_SSL_FOR_WEBHOOK` for true. Our current template were skipping setting `ENABLE_SSL_FOR_WEBHOOK` to False, because condition were negative 🙃