### PR TITLE
Fix Minio's provisioning configuration

### DIFF
--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.17
+version: 0.1.18
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -146,9 +146,11 @@ minio:
     rootPassword: password
 
   provisioning:
+    # -- Minio provisioning enabled
+    enabled: true
     # -- Minio buckets to provision
     buckets:
-      - iterativeai
+      - name: iterativeai
 
 redis:
   # -- Redis enabled


### PR DESCRIPTION
The Minio chart was misconfigured, so the `iterativeai` bucket wouldn't be created. This change fixes the configuration.