### PR TITLE
Remove deprecated sessionCookieSecure option

### DIFF
--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.18
+version: 0.1.19
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.48.0"
+appVersion: "v1.53.4"
 
 dependencies:
   - name: minio

--- a/charts/studio/templates/configmap-studio.yaml
+++ b/charts/studio/templates/configmap-studio.yaml
@@ -97,8 +97,6 @@ data:
   {{- end }}
   SCM_PROVIDERS: {{ $scmProviders | join "," | quote }}
 
-  SESSION_COOKIE_SECURE: {{ .Values.global.sessionCookieSecure | quote | title }}
-
   SOCIAL_AUTH_REDIRECT_IS_HTTPS: "False"
 
   {{- if .Values.global.ingress.enabled }}

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -16,9 +16,6 @@ global:
   # We recommend you set this externally. If left empty, a random key will be generated.
   secretKey: ""
 
-  # -- Studio: Enable secure flag on session cookies
-  sessionCookieSecure: true
-
   # -- Studio: Custom CA certificate in PEM format
   # customCaCert: |-
   #   -----BEGIN CERTIFICATE-----


### PR DESCRIPTION
Studio no longer supports the `sessionCookieSecure` option. Instead, it's now automatically set depending on the Studio and SCM provider URLs scheme.

`Upstream: #5236`