### PR TITLE
Disable Minio by default, add var for S3 region

### DIFF
--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.19
+version: 0.1.20
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.53.4"
+appVersion: "v1.55.0"
 
 dependencies:
   - name: minio

--- a/charts/studio/templates/configmap-studio.yaml
+++ b/charts/studio/templates/configmap-studio.yaml
@@ -24,14 +24,12 @@ data:
   BLOBVAULT_BUCKET: {{ .Values.global.blobvault.bucket | quote }}
   {{- end }}
 
-  {{- if .Values.global.blobvault.endpointUrl }}
-  BLOBVAULT_ENDPOINT_URL: {{ .Values.global.blobvault.endpointUrl }}
-  {{- else }}
-  BLOBVAULT_ENDPOINT_URL: "http://{{ .Values.minio.fullnameOverride }}.{{ .Release.Namespace }}.svc.cluster.local:9000"
+  {{- if .Values.global.blobvault.regionName }}
+  BLOBVAULT_AWS_REGION: {{ .Values.global.blobvault.regionName }}
   {{- end }}
 
-  {{- if .Values.global.blobvault.endpointUrlFe }}
-  BLOBVAULT_ENDPOINT_URL_FE: {{ .Values.global.blobvault.endpointUrlFe }}
+  {{- if .Values.global.blobvault.endpointUrl }}
+  BLOBVAULT_ENDPOINT_URL: {{ .Values.global.blobvault.endpointUrl }}
   {{- end }}
   
   {{- if .Values.global.celery.brokerUrl }}

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -35,6 +35,8 @@ global:
     accessKeyId: "admin"
     # -- Blobvault S3 secret access key ID
     secretAccessKeyId: "password"
+    # -- Blobvault S3 region
+    regionName: ""
 
   celery:
     # -- Celery broker URL
@@ -131,7 +133,7 @@ global:
 # Dependencies
 minio:
   # -- Minio enabled
-  enabled: true
+  enabled: false
   # -- Minio name override
   fullnameOverride: studio-minio
 


### PR DESCRIPTION
Minio will get removed due to integration problems, so let's disable it by default and recommend hosted block storage (such as AWS S3) for now.

To get AWS S3 to work, I've added a new variable, `.Values.global.blobvault.regionName`, for specifying the region the bucket is hosted in.