### PR TITLE
Support configuring extra env variables in pods

### DIFF
--- a/charts/studio/templates/configmap-studio-backend.yaml
+++ b/charts/studio/templates/configmap-studio-backend.yaml
@@ -3,6 +3,4 @@ kind: ConfigMap
 metadata:
   name: studio-backend
 data:
-{{- range $k, $v := .Values.studioBackend.envVars }}
-  {{ $v.name }}: "{{ $v.value }}"
-{{- end }}
+{{- toYaml .Values.studioBackend.envVars  | nindent 4 }}

--- a/charts/studio/templates/configmap-studio-backend.yaml
+++ b/charts/studio/templates/configmap-studio-backend.yaml
@@ -3,4 +3,6 @@ kind: ConfigMap
 metadata:
   name: studio-backend
 data:
-{{- toYaml .Values.studioBackend.envVars  | nindent 4 }}
+{{- with .Values.studioBackend.envVars}}
+{{-  toYaml . | nindent 2 }}
+{{- end }}

--- a/charts/studio/templates/configmap-studio-backend.yaml
+++ b/charts/studio/templates/configmap-studio-backend.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: studio-backend
+data:
+{{- range $k, $v := .Values.studioBackend.envVars }}
+  {{ $v.name }}: "{{ $v.value }}"
+{{- end }}

--- a/charts/studio/templates/configmap-studio-beat.yaml
+++ b/charts/studio/templates/configmap-studio-beat.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: studio-beat
+data:
+{{- range $k, $v := .Values.studioBeat.envVars }}
+  {{ $v.name }}: "{{ $v.value }}"
+{{- end }}

--- a/charts/studio/templates/configmap-studio-beat.yaml
+++ b/charts/studio/templates/configmap-studio-beat.yaml
@@ -3,6 +3,4 @@ kind: ConfigMap
 metadata:
   name: studio-beat
 data:
-{{- range $k, $v := .Values.studioBeat.envVars }}
-  {{ $v.name }}: "{{ $v.value }}"
-{{- end }}
+{{- toYaml .Values.studioBeat.envVars  | nindent 4 }}

--- a/charts/studio/templates/configmap-studio-beat.yaml
+++ b/charts/studio/templates/configmap-studio-beat.yaml
@@ -3,4 +3,6 @@ kind: ConfigMap
 metadata:
   name: studio-beat
 data:
-{{- toYaml .Values.studioBeat.envVars  | nindent 4 }}
+{{- with .Values.studioBeat.envVars}}
+{{-  toYaml . | nindent 2 }}
+{{- end }}

--- a/charts/studio/templates/configmap-studio-ui.yaml
+++ b/charts/studio/templates/configmap-studio-ui.yaml
@@ -3,4 +3,6 @@ kind: ConfigMap
 metadata:
   name: studio-ui
 data:
-{{- toYaml .Values.studioUi.envVars  | nindent 4 }}
+{{- with .Values.studioUi.envVars}}
+{{-  toYaml . | nindent 2 }}
+{{- end }}

--- a/charts/studio/templates/configmap-studio-ui.yaml
+++ b/charts/studio/templates/configmap-studio-ui.yaml
@@ -3,6 +3,4 @@ kind: ConfigMap
 metadata:
   name: studio-ui
 data:
-{{- range $k, $v := .Values.studioUi.envVars }}
-  {{ $v.name }}: "{{ $v.value }}"
-{{- end }}
+{{- toYaml .Values.studioUi.envVars  | nindent 4 }}

--- a/charts/studio/templates/configmap-studio-ui.yaml
+++ b/charts/studio/templates/configmap-studio-ui.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: studio-ui
+data:
+{{- range $k, $v := .Values.studioUi.envVars }}
+  {{ $v.name }}: "{{ $v.value }}"
+{{- end }}

--- a/charts/studio/templates/configmap-studio-worker.yaml
+++ b/charts/studio/templates/configmap-studio-worker.yaml
@@ -3,6 +3,4 @@ kind: ConfigMap
 metadata:
   name: studio-worker
 data:
-{{- range $k, $v := .Values.studioWorker.envVars }}
-  {{ $v.name }}: "{{ $v.value }}"
-{{- end }}
+{{- toYaml .Values.studioWorker.envVars  | nindent 4 }}

--- a/charts/studio/templates/configmap-studio-worker.yaml
+++ b/charts/studio/templates/configmap-studio-worker.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: studio-worker
+data:
+{{- range $k, $v := .Values.studioWorker.envVars }}
+  {{ $v.name }}: "{{ $v.value }}"
+{{- end }}

--- a/charts/studio/templates/configmap-studio-worker.yaml
+++ b/charts/studio/templates/configmap-studio-worker.yaml
@@ -3,4 +3,6 @@ kind: ConfigMap
 metadata:
   name: studio-worker
 data:
-{{- toYaml .Values.studioWorker.envVars  | nindent 4 }}
+{{- with .Values.studioWorker.envVars}}
+{{-  toYaml . | nindent 2 }}
+{{- end }}

--- a/charts/studio/templates/configmap-studio.yaml
+++ b/charts/studio/templates/configmap-studio.yaml
@@ -3,9 +3,7 @@ kind: ConfigMap
 metadata:
   name: studio
 data:
-{{- range $k, $v := .Values.global.envVars }}
-  {{ $v.name }}: "{{ $v.value }}"
-{{- end }}
+{{- toYaml .Values.global.envVars  | nindent 4 }}
 
   ALLOWED_HOSTS: "*"
   API_URL: "http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{.Values.global.host }}/api"

--- a/charts/studio/templates/configmap-studio.yaml
+++ b/charts/studio/templates/configmap-studio.yaml
@@ -3,6 +3,10 @@ kind: ConfigMap
 metadata:
   name: studio
 data:
+{{- range $k, $v := .Values.global.envVars }}
+  {{ $v.name }}: "{{ $v.value }}"
+{{- end }}
+
   ALLOWED_HOSTS: "*"
   API_URL: "http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{.Values.global.host }}/api"
   UI_URL: "http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{.Values.global.host }}/"
@@ -104,3 +108,4 @@ data:
   {{- else }}
   SOCIAL_AUTH_ALLOWED_REDIRECT_HOSTS: "studio-ui.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.studioUi.service.port }},studio-backend.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.studioBackend.service.port }}"
   {{- end }}
+

--- a/charts/studio/templates/configmap-studio.yaml
+++ b/charts/studio/templates/configmap-studio.yaml
@@ -3,7 +3,9 @@ kind: ConfigMap
 metadata:
   name: studio
 data:
-{{- toYaml .Values.global.envVars  | nindent 4 }}
+{{- with .Values.global.envVars}}
+{{-  toYaml . | nindent 2 }}
+{{- end }}
 
   ALLOWED_HOSTS: "*"
   API_URL: "http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{.Values.global.host }}/api"

--- a/charts/studio/templates/deployment-studio-backend.yaml
+++ b/charts/studio/templates/deployment-studio-backend.yaml
@@ -63,6 +63,8 @@ spec:
           envFrom:
             - configMapRef:
                 name: studio
+            - configMapRef:
+                name: studio-backend
             - secretRef:
                 name: studio
       {{- if .Values.global.customCaCert }}

--- a/charts/studio/templates/deployment-studio-beat.yaml
+++ b/charts/studio/templates/deployment-studio-beat.yaml
@@ -49,6 +49,8 @@ spec:
           envFrom:
             - configMapRef:
                 name: studio
+            - configMapRef:
+                name: studio-beat
             - secretRef:
                 name: studio
           {{- if .Values.global.customCaCert }}

--- a/charts/studio/templates/deployment-studio-ui.yaml
+++ b/charts/studio/templates/deployment-studio-ui.yaml
@@ -53,6 +53,8 @@ spec:
           envFrom:
             - configMapRef:
                 name: studio
+            - configMapRef:
+                name: studio-ui
             - secretRef:
                 name: studio
           {{- if .Values.global.customCaCert }}

--- a/charts/studio/templates/deployment-studio-worker.yaml
+++ b/charts/studio/templates/deployment-studio-worker.yaml
@@ -49,6 +49,8 @@ spec:
           envFrom:
             - configMapRef:
                 name: studio
+            - configMapRef:
+                name: studio-worker
             - secretRef:
                 name: studio
           {{- if .Values.global.customCaCert }}

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -24,6 +24,14 @@ global:
   #
   customCaCert: ""
 
+  # -- Studio: Additional environment variables for all pods
+  envVars: []
+  # Example:
+  # envVars: [
+  #   - name: DEBUG
+  #     value: True
+  # ]
+
   blobvault:
     # -- Blobvault S3 bucket name
     bucket: "iterativeai"
@@ -175,6 +183,14 @@ postgresql:
         database: iterativeai
 
 studioUi:
+  # -- Studio: Additional environment variables for ui pods
+  envVars: []
+  # Example:
+  # envVars: [
+  #   - name: DEBUG
+  #     value: True
+  # ]
+
   replicaCount: 1
 
   image:
@@ -230,6 +246,14 @@ studioUi:
   affinity: {}
 
 studioBackend:
+  # -- Studio: Additional environment variables for backend pods
+  envVars: []
+  # Example:
+  # envVars: [
+  #   - name: DEBUG
+  #     value: True
+  # ]
+
   replicaCount: 1
 
   image:
@@ -285,6 +309,14 @@ studioBackend:
   affinity: {}
 
 studioBeat:
+  # -- Studio: Additional environment variables for beat pods
+  envVars: []
+  # Example:
+  # envVars: [
+  #   - name: DEBUG
+  #     value: True
+  # ]
+
   replicaCount: 1
 
   resources: {}
@@ -330,6 +362,14 @@ studioBeat:
   affinity: {}
 
 studioWorker:
+  # -- Studio: Additional environment variables for worker pods
+  envVars: []
+  # Example:
+  # envVars: [
+  #   - name: DEBUG
+  #     value: True
+  # ]
+
   replicaCount: 1
 
   resources: {}

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -25,12 +25,10 @@ global:
   customCaCert: ""
 
   # -- Studio: Additional environment variables for all pods
-  envVars: []
+  envVars: {}
   # Example:
-  # envVars: [
-  #   - name: DEBUG
-  #     value: True
-  # ]
+  # envVars: 
+  #   DEBUG: True
 
   blobvault:
     # -- Blobvault S3 bucket name
@@ -184,12 +182,10 @@ postgresql:
 
 studioUi:
   # -- Studio: Additional environment variables for ui pods
-  envVars: []
+  envVars: {}
   # Example:
-  # envVars: [
-  #   - name: DEBUG
-  #     value: True
-  # ]
+  # envVars: 
+  #   DEBUG: True
 
   replicaCount: 1
 
@@ -247,12 +243,10 @@ studioUi:
 
 studioBackend:
   # -- Studio: Additional environment variables for backend pods
-  envVars: []
+  envVars: {}
   # Example:
-  # envVars: [
-  #   - name: DEBUG
-  #     value: True
-  # ]
+  # envVars: 
+  #   DEBUG: True
 
   replicaCount: 1
 
@@ -310,12 +304,10 @@ studioBackend:
 
 studioBeat:
   # -- Studio: Additional environment variables for beat pods
-  envVars: []
+  envVars: {}
   # Example:
-  # envVars: [
-  #   - name: DEBUG
-  #     value: True
-  # ]
+  # envVars: 
+  #   DEBUG: True
 
   replicaCount: 1
 
@@ -363,12 +355,10 @@ studioBeat:
 
 studioWorker:
   # -- Studio: Additional environment variables for worker pods
-  envVars: []
+  envVars: {}
   # Example:
-  # envVars: [
-  #   - name: DEBUG
-  #     value: True
-  # ]
+  # envVars: 
+  #   DEBUG: True
 
   replicaCount: 1
 


### PR DESCRIPTION
Sometimes, we want to pass extra environment variables to pods. To achieve this, I've implemented a new variable, `Values.global.envVars`, which passes extra environment variables across all pods, plus four new variables, `.Values.studio{Backend,Beat,Ui,Worker}.envVars` that are specific to each pod.


Closes https://github.com/iterative/helm-charts/issues/78
