### PR TITLE
Add option for blobvault PersistentVolume size

### DIFF
--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.21
+version: 0.1.22
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/studio/templates/persistentvolume.yaml
+++ b/charts/studio/templates/persistentvolume.yaml
@@ -9,4 +9,4 @@ spec:
   storageClassName: local-path
   resources:
     requests:
-      storage: 30Gi
+      storage: {{ .Values.global.blobvault.persistentVolume.size }}

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -31,6 +31,10 @@ global:
   #   DEBUG: True
 
   blobvault:
+    # -- Blobvault local backing store size
+    persistentVolume:
+      size: 30Gi
+
     # -- Blobvault S3 bucket name
     bucket: ""
     # -- Blobvault S3 endpoint URL
@@ -41,7 +45,7 @@ global:
     secretAccessKeyId: ""
     # -- Blobvault S3 region
     regionName: ""
-
+      
   celery:
     # -- Celery broker URL
     brokerUrl: ""


### PR DESCRIPTION
This PR makes it so that users can configure the size of the PersistentVolume used as the blobvault storage.