### PR TITLE
Remove deprecated ENABLE_SSL_FOR_WEBHOOK variable

### DIFF
--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.22
+version: 0.1.23
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/studio/templates/configmap-studio.yaml
+++ b/charts/studio/templates/configmap-studio.yaml
@@ -11,8 +11,6 @@ data:
   API_URL: "http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{.Values.global.host }}/api"
   UI_URL: "http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{.Values.global.host }}/"
 
-  ENABLE_SSL_FOR_WEBHOOK: {{ .Values.global.scmProviders.enableWebhookSSL | quote | title }}
-
   {{- if .Values.global.scmProviders.bitbucket.url }}
   BITBUCKET_URL: {{.Values.global.scmProviders.bitbucket.url | quote }}
   {{- end }}

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -70,9 +70,6 @@ global:
     databasePassword: "postgres"
 
   scmProviders:
-    # Enable SSL for webhooks
-    enableWebhookSSL: true
-
     github:
       # -- GitHub enabled
       enabled: false


### PR DESCRIPTION
This environment variable is no longer supported in Studio.

Webhook TLS is automatically enabled when the user has configured Studio and the SCM providers with `https` URLs.