### PR TITLE
Make the blobvault PV StorageClass configurable

### DIFF
--- a/charts/studio/templates/persistentvolume.yaml
+++ b/charts/studio/templates/persistentvolume.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: local-path
+  storageClassName: {{ .Values.global.blobvault.persistentVolume.storageClassName }}
   resources:
     requests:
       storage: {{ .Values.global.blobvault.persistentVolume.size }}

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -33,6 +33,7 @@ global:
   blobvault:
     # -- Blobvault local backing store size
     persistentVolume:
+      storageClassName: local-path
       size: 30Gi
 
     # -- Blobvault S3 bucket name


### PR DESCRIPTION
Users may want to use different StorageClasses for the blobvault PersistentVolume, so make it configurable.