### PR TITLE
Fix envVars example

### DIFF
--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.23
+version: 0.1.24
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -28,7 +28,7 @@ global:
   envVars: {}
   # Example:
   # envVars: 
-  #   DEBUG: True
+  #   DEBUG: "True"
 
   blobvault:
     # -- Blobvault local backing store size
@@ -254,7 +254,7 @@ studioUi:
   envVars: {}
   # Example:
   # envVars: 
-  #   DEBUG: True
+  #   DEBUG: "True"
 
   replicaCount: 1
 
@@ -311,7 +311,7 @@ studioBackend:
   envVars: {}
   # Example:
   # envVars: 
-  #   DEBUG: True
+  #   DEBUG: "True"
 
   replicaCount: 1
 
@@ -368,7 +368,7 @@ studioBeat:
   envVars: {}
   # Example:
   # envVars: 
-  #   DEBUG: True
+  #   DEBUG: "True"
 
   replicaCount: 1
 
@@ -415,7 +415,7 @@ studioWorker:
   envVars: {}
   # Example:
   # envVars: 
-  #   DEBUG: True
+  #   DEBUG: "True"
 
   replicaCount: 1
 


### PR DESCRIPTION
The provided envVars example would result in errors such as:

```
Error: UPGRADE FAILED: cannot patch "studio" with kind ConfigMap:  "" is invalid: patch: Invalid value:
json: cannot unmarshal bool into Go struct field ConfigMap.data of type string
```

To solve this, we need to quote the dictionary item's value so the boolean gets interpreted as a string.