### PR TITLE
Make the ingress host field optional

### DIFF
--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.25
+version: 0.1.26
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/studio/templates/ingress-blobvault.yaml
+++ b/charts/studio/templates/ingress-blobvault.yaml
@@ -14,10 +14,10 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: blobvault
-  {{- with .Values.global.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2
+  {{- with .Values.global.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   {{- if and .Values.global.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}

--- a/charts/studio/templates/ingress-blobvault.yaml
+++ b/charts/studio/templates/ingress-blobvault.yaml
@@ -23,7 +23,7 @@ spec:
   {{- if and .Values.global.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
   ingressClassName: {{ .Values.global.ingress.className }}
   {{- end }}
-  {{- if .Values.global.ingress.tlsEnabled and .Values.global.ingress.hostnameEnabled }}
+  {{- if and .Values.global.ingress.tlsEnabled .Values.global.ingress.hostnameEnabled }}
   tls:
     - hosts:
         - {{ .Values.global.host }}

--- a/charts/studio/templates/ingress-blobvault.yaml
+++ b/charts/studio/templates/ingress-blobvault.yaml
@@ -13,12 +13,13 @@ apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
-  name: app
+  name: blobvault
   labels:
     {{- include "studio-ui.labels" . | nindent 4 }}
   {{- with .Values.global.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
   {{- end }}
 spec:
   {{- if and .Values.global.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
@@ -33,49 +34,22 @@ spec:
   rules:
     - http:
         paths:
-          - path: /
+          - path: /blobvault(/|$)(.*)
             {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
             pathType: ImplementationSpecific
             {{- end }}
             backend:
             {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
-                name: studio-ui
+                name: {{ .Release.Name }}-nginx
                 port:
-                  number: {{ .Values.studioUi.service.port }}
+                  name: http
               {{- else }}
-              serviceName: studio-ui
-              servicePort: {{ .Values.studioUi.service.port }}
-              {{- end }}
-          - path: /api
-            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
-            pathType: ImplementationSpecific
-            {{- end }}
-            backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-              service:
-                name: studio-backend
-                port:
-                  number: {{ .Values.studioBackend.service.port }}
-              {{- else }}
-              serviceName: studio-backend
-              servicePort: {{ .Values.studioBackend.service.port }}
-              {{- end }}
-          - path: /webhook
-            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
-            pathType: ImplementationSpecific
-            {{- end }}
-            backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-              service:
-                name: studio-backend
-                port:
-                  number: {{ .Values.studioBackend.service.port }}
-              {{- else }}
-              serviceName: studio-backend
-              servicePort: {{ .Values.studioBackend.service.port }}
+              serviceName: {{ .Release.Name }}-nginx
+              servicePort: 80
               {{- end }}
       {{- if .Values.global.ingress.hostnameEnabled }}
       host: {{ .Values.global.host }}
       {{- end }}
 {{- end }}
+

--- a/charts/studio/templates/ingress-blobvault.yaml
+++ b/charts/studio/templates/ingress-blobvault.yaml
@@ -14,8 +14,6 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: blobvault
-  labels:
-    {{- include "studio-ui.labels" . | nindent 4 }}
   {{- with .Values.global.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/studio/templates/ingress-blobvault.yaml
+++ b/charts/studio/templates/ingress-blobvault.yaml
@@ -23,7 +23,7 @@ spec:
   {{- if and .Values.global.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
   ingressClassName: {{ .Values.global.ingress.className }}
   {{- end }}
-  {{- if .Values.global.ingress.tlsEnabled }}
+  {{- if .Values.global.ingress.tlsEnabled and .Values.global.ingress.hostnameEnabled }}
   tls:
     - hosts:
         - {{ .Values.global.host }}

--- a/charts/studio/templates/ingress-studio.yaml
+++ b/charts/studio/templates/ingress-studio.yaml
@@ -24,7 +24,7 @@ spec:
   {{- if and .Values.global.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
   ingressClassName: {{ .Values.global.ingress.className }}
   {{- end }}
-  {{- if .Values.global.ingress.tlsEnabled }}
+  {{- if .Values.global.ingress.tlsEnabled and .Values.global.ingress.hostnameEnabled }}
   tls:
     - hosts:
         - {{ .Values.global.host }}

--- a/charts/studio/templates/ingress-studio.yaml
+++ b/charts/studio/templates/ingress-studio.yaml
@@ -24,7 +24,7 @@ spec:
   {{- if and .Values.global.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
   ingressClassName: {{ .Values.global.ingress.className }}
   {{- end }}
-  {{- if .Values.global.ingress.tlsEnabled and .Values.global.ingress.hostnameEnabled }}
+  {{- if and .Values.global.ingress.tlsEnabled .Values.global.ingress.hostnameEnabled }}
   tls:
     - hosts:
         - {{ .Values.global.host }}

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -55,6 +55,7 @@ global:
 
   ingress:
     enabled: true
+    hostnameEnabled: true
     className: ""
     annotations: {}
       # kubernetes.io/ingress.class: nginx
@@ -139,11 +140,7 @@ nginx:
     type: ClusterIP
 
   ingress:
-    enabled: true
-    hostname: "localhost"
-    path: /blobvault(/|$)(.*)
-    annotations:
-      nginx.ingress.kubernetes.io/rewrite-target: /$2
+    enabled: false
 
   extraVolumes:
   - name: blobvault


### PR DESCRIPTION
When a user accesses Studio on its IP address, the routing in the ingresses will not work, as the ingresses will only route requests that match the Studio hostname. To fix this, I've added a new variable, `global.ingress.hostnameEnabled`, allowing the user to disable binding the ingresses to a specific hostname.

Additionally, I've disabled nginx's ingress manifest and made our own, as theirs do not support conditional inclusion of the `host` field.