### PR TITLE
Add base path support

### DIFF
--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.26
+version: 0.1.27
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.59.0"
+appVersion: "v1.78.0"
 
 dependencies:
   - name: nginx

--- a/charts/studio/templates/_helpers.tpl
+++ b/charts/studio/templates/_helpers.tpl
@@ -124,3 +124,8 @@ checksum/configmap-studio: {{ include (print $.Template.BasePath "/configmap-stu
 checksum/configmap-ca-cert: {{ include (print $.Template.BasePath "/configmap-ca-cert.yaml") . | sha256sum }}
 checksum/secret-studio: {{ include (print $.Template.BasePath "/secret-studio.yaml") . | sha256sum }}
 {{- end }}
+
+
+{{- define "studio.basePath" -}}
+{{- printf "%s" .Values.global.basePath | trimPrefix "/" | trimSuffix "/" }}
+{{- end }}

--- a/charts/studio/templates/configmap-studio.yaml
+++ b/charts/studio/templates/configmap-studio.yaml
@@ -11,10 +11,6 @@ data:
   API_URL: "http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{.Values.global.host }}{{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}/{{ include "studio.basePath" . }}{{- end }}/api"
   UI_URL: "http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{.Values.global.host }}/{{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}{{ include "studio.basePath" . }}{{- end }}"
 
-  {{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}
-  BASE_PATH: {{ include "studio.basePath" . }}
-  {{- end }}
-
   {{- if .Values.global.scmProviders.bitbucket.url }}
   BITBUCKET_URL: {{.Values.global.scmProviders.bitbucket.url | quote }}
   {{- end }}

--- a/charts/studio/templates/configmap-studio.yaml
+++ b/charts/studio/templates/configmap-studio.yaml
@@ -8,8 +8,8 @@ data:
 {{- end }}
 
   ALLOWED_HOSTS: "*"
-  API_URL: "http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{.Values.global.host }}{{- if .Values.global.basePath }}/{{ include "studio.basePath" . }}{{- end }}/api"
-  UI_URL: "http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{.Values.global.host }}/{{- if .Values.global.basePath }}{{ include "studio.basePath" . }}{{- end }}"
+  API_URL: "http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{.Values.global.host }}{{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}/{{ include "studio.basePath" . }}{{- end }}/api"
+  UI_URL: "http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{.Values.global.host }}/{{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}{{ include "studio.basePath" . }}{{- end }}"
 
   {{- if .Values.global.scmProviders.bitbucket.url }}
   BITBUCKET_URL: {{.Values.global.scmProviders.bitbucket.url | quote }}
@@ -35,8 +35,8 @@ data:
   {{- else }}
   BLOBVAULT_LOCAL_ENABLED: "True"
   BLOBVAULT_LOCAL_PATH: "/blobvault"
-  BLOBVAULT_ENDPOINT_URL: "http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{.Values.global.host }}{{- if .Values.global.basePath }}/{{ include "studio.basePath" . }}{{- end }}/blobvault"
-  BLOBVAULT_ENDPOINT_URL_FE: "http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{.Values.global.host }}{{- if .Values.global.basePath }}/{{ include "studio.basePath" . }}{{- end }}/blobvault"
+  BLOBVAULT_ENDPOINT_URL: "http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{.Values.global.host }}{{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}/{{ include "studio.basePath" . }}{{- end }}/blobvault"
+  BLOBVAULT_ENDPOINT_URL_FE: "http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{.Values.global.host }}{{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}/{{ include "studio.basePath" . }}{{- end }}/blobvault"
   {{- end }}
 
   {{- if .Values.global.celery.brokerUrl }}

--- a/charts/studio/templates/configmap-studio.yaml
+++ b/charts/studio/templates/configmap-studio.yaml
@@ -11,6 +11,10 @@ data:
   API_URL: "http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{.Values.global.host }}{{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}/{{ include "studio.basePath" . }}{{- end }}/api"
   UI_URL: "http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{.Values.global.host }}/{{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}{{ include "studio.basePath" . }}{{- end }}"
 
+  {{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}
+  BASE_PATH: /{{ include "studio.basePath" . }}
+  {{- end }}
+
   {{- if .Values.global.scmProviders.bitbucket.url }}
   BITBUCKET_URL: {{.Values.global.scmProviders.bitbucket.url | quote }}
   {{- end }}
@@ -109,4 +113,3 @@ data:
   {{- else }}
   SOCIAL_AUTH_ALLOWED_REDIRECT_HOSTS: "studio-ui.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.studioUi.service.port }},studio-backend.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.studioBackend.service.port }}"
   {{- end }}
-

--- a/charts/studio/templates/configmap-studio.yaml
+++ b/charts/studio/templates/configmap-studio.yaml
@@ -8,8 +8,8 @@ data:
 {{- end }}
 
   ALLOWED_HOSTS: "*"
-  API_URL: "http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{.Values.global.host }}/api"
-  UI_URL: "http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{.Values.global.host }}/"
+  API_URL: "http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{.Values.global.host }}{{- if .Values.global.basePath }}/{{ include "studio.basePath" . }}{{- end }}/api"
+  UI_URL: "http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{.Values.global.host }}/{{- if .Values.global.basePath }}{{ include "studio.basePath" . }}{{- end }}"
 
   {{- if .Values.global.scmProviders.bitbucket.url }}
   BITBUCKET_URL: {{.Values.global.scmProviders.bitbucket.url | quote }}
@@ -35,8 +35,8 @@ data:
   {{- else }}
   BLOBVAULT_LOCAL_ENABLED: "True"
   BLOBVAULT_LOCAL_PATH: "/blobvault"
-  BLOBVAULT_ENDPOINT_URL: "http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{.Values.global.host }}/blobvault"
-  BLOBVAULT_ENDPOINT_URL_FE: "http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{.Values.global.host }}/blobvault"
+  BLOBVAULT_ENDPOINT_URL: "http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{.Values.global.host }}{{- if .Values.global.basePath }}/{{ include "studio.basePath" . }}{{- end }}/blobvault"
+  BLOBVAULT_ENDPOINT_URL_FE: "http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{.Values.global.host }}{{- if .Values.global.basePath }}/{{ include "studio.basePath" . }}{{- end }}/blobvault"
   {{- end }}
 
   {{- if .Values.global.celery.brokerUrl }}

--- a/charts/studio/templates/configmap-studio.yaml
+++ b/charts/studio/templates/configmap-studio.yaml
@@ -11,6 +11,10 @@ data:
   API_URL: "http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{.Values.global.host }}{{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}/{{ include "studio.basePath" . }}{{- end }}/api"
   UI_URL: "http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{.Values.global.host }}/{{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}{{ include "studio.basePath" . }}{{- end }}"
 
+  {{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}
+  BASE_PATH: {{ include "studio.basePath" . }}
+  {{- end }}
+
   {{- if .Values.global.scmProviders.bitbucket.url }}
   BITBUCKET_URL: {{.Values.global.scmProviders.bitbucket.url | quote }}
   {{- end }}

--- a/charts/studio/templates/deployment-studio-ui.yaml
+++ b/charts/studio/templates/deployment-studio-ui.yaml
@@ -46,9 +46,9 @@ spec:
           readinessProbe:
             httpGet:
             {{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}
-              path: /{{ include "studio.basePath" . }}/fapi/health
+              path: /{{ include "studio.basePath" . }}/{{- if semverCompare ">=1.80.0" (.Values.studioUi.image.tag | default .Chart.AppVersion) }}f{{end}}api/health
             {{- else }}
-              path: /fapi/health
+              path: /{{- if semverCompare ">=1.80.0" (.Values.studioUi.image.tag | default .Chart.AppVersion) }}f{{end}}api/health
             {{- end }}
               port: 3000
             initialDelaySeconds: 5

--- a/charts/studio/templates/deployment-studio-ui.yaml
+++ b/charts/studio/templates/deployment-studio-ui.yaml
@@ -45,11 +45,7 @@ spec:
             periodSeconds: 10
           readinessProbe:
             httpGet:
-            {{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}
-              path: /{{ include "studio.basePath" . }}/api/health
-            {{- else }}
               path: /api/health
-            {{- end }}
               port: 3000
             initialDelaySeconds: 5
             periodSeconds: 25

--- a/charts/studio/templates/deployment-studio-ui.yaml
+++ b/charts/studio/templates/deployment-studio-ui.yaml
@@ -46,9 +46,9 @@ spec:
           readinessProbe:
             httpGet:
             {{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}
-              path: /{{ include "studio.basePath" . }}/{{- if semverCompare ">=1.77.0" (.Values.studioUi.image.tag | default .Chart.AppVersion) }}f{{end}}api/health
+              path: /{{ include "studio.basePath" . }}/{{- if semverCompare ">=1.78.0" (.Values.studioUi.image.tag | default .Chart.AppVersion) }}f{{end}}api/health
             {{- else }}
-              path: /{{- if semverCompare ">=1.77.0" (.Values.studioUi.image.tag | default .Chart.AppVersion) }}f{{end}}api/health
+              path: /{{- if semverCompare ">=1.78.0" (.Values.studioUi.image.tag | default .Chart.AppVersion) }}f{{end}}api/health
             {{- end }}
               port: 3000
             initialDelaySeconds: 5

--- a/charts/studio/templates/deployment-studio-ui.yaml
+++ b/charts/studio/templates/deployment-studio-ui.yaml
@@ -45,7 +45,11 @@ spec:
             periodSeconds: 10
           readinessProbe:
             httpGet:
+            {{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}
+              path: /{{ include "studio.basePath" . }}/api/health
+            {{- else }}
               path: /api/health
+            {{- end }}
               port: 3000
             initialDelaySeconds: 5
             periodSeconds: 25

--- a/charts/studio/templates/deployment-studio-ui.yaml
+++ b/charts/studio/templates/deployment-studio-ui.yaml
@@ -46,9 +46,9 @@ spec:
           readinessProbe:
             httpGet:
             {{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}
-              path: /{{ include "studio.basePath" . }}/api/health
+              path: /{{ include "studio.basePath" . }}/fapi/health
             {{- else }}
-              path: /api/health
+              path: /fapi/health
             {{- end }}
               port: 3000
             initialDelaySeconds: 5

--- a/charts/studio/templates/deployment-studio-ui.yaml
+++ b/charts/studio/templates/deployment-studio-ui.yaml
@@ -46,9 +46,9 @@ spec:
           readinessProbe:
             httpGet:
             {{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}
-              path: /{{ include "studio.basePath" . }}/{{- if semverCompare ">=1.80.0" (.Values.studioUi.image.tag | default .Chart.AppVersion) }}f{{end}}api/health
+              path: /{{ include "studio.basePath" . }}/{{- if semverCompare ">=1.77.0" (.Values.studioUi.image.tag | default .Chart.AppVersion) }}f{{end}}api/health
             {{- else }}
-              path: /{{- if semverCompare ">=1.80.0" (.Values.studioUi.image.tag | default .Chart.AppVersion) }}f{{end}}api/health
+              path: /{{- if semverCompare ">=1.77.0" (.Values.studioUi.image.tag | default .Chart.AppVersion) }}f{{end}}api/health
             {{- end }}
               port: 3000
             initialDelaySeconds: 5

--- a/charts/studio/templates/ingress-blobvault.yaml
+++ b/charts/studio/templates/ingress-blobvault.yaml
@@ -33,7 +33,7 @@ spec:
     - http:
         paths:
           {{- if .Values.global.basePath }}
-          - path: /{{ .Values.global.basePath | trimPrefix "/" | trimSuffix "/" }}/blobvault(/|$)(.*)
+          - path: /{{ include "studio.basePath" . }}/blobvault(/|$)(.*)
           {{- else }}
           - path: /blobvault(/|$)(.*)
           {{- end }}

--- a/charts/studio/templates/ingress-blobvault.yaml
+++ b/charts/studio/templates/ingress-blobvault.yaml
@@ -32,7 +32,11 @@ spec:
   rules:
     - http:
         paths:
+          {{- if .Values.global.basePath -}}
+          - path: /{{ .Values.global.basePath | trimPrefix "/" | trimSuffix "/" }}/blobvault(/|$)(.*)
+          {{- else -}}
           - path: /blobvault(/|$)(.*)
+          {{- end }}
             {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
             pathType: ImplementationSpecific
             {{- end }}

--- a/charts/studio/templates/ingress-blobvault.yaml
+++ b/charts/studio/templates/ingress-blobvault.yaml
@@ -32,9 +32,9 @@ spec:
   rules:
     - http:
         paths:
-          {{- if .Values.global.basePath -}}
+          {{- if .Values.global.basePath }}
           - path: /{{ .Values.global.basePath | trimPrefix "/" | trimSuffix "/" }}/blobvault(/|$)(.*)
-          {{- else -}}
+          {{- else }}
           - path: /blobvault(/|$)(.*)
           {{- end }}
             {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}

--- a/charts/studio/templates/ingress-blobvault.yaml
+++ b/charts/studio/templates/ingress-blobvault.yaml
@@ -32,7 +32,7 @@ spec:
   rules:
     - http:
         paths:
-          {{- if .Values.global.basePath }}
+          {{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}
           - path: /{{ include "studio.basePath" . }}/blobvault(/|$)(.*)
           {{- else }}
           - path: /blobvault(/|$)(.*)

--- a/charts/studio/templates/ingress-studio-api.yaml
+++ b/charts/studio/templates/ingress-studio-api.yaml
@@ -17,7 +17,7 @@ metadata:
   labels:
     {{- include "studio-ui.labels" . | nindent 4 }}
   annotations:
-    {{- if .Values.global.basePath }}
+    {{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     {{- end }}
   {{- with .Values.global.ingress.annotations }}
@@ -36,7 +36,7 @@ spec:
   rules:
     - http:
         paths:
-          {{- if .Values.global.basePath }}
+          {{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}
           - path: /{{ include "studio.basePath" . }}/(api(?:/|$).*)
           {{- else }}
           - path: /api

--- a/charts/studio/templates/ingress-studio-api.yaml
+++ b/charts/studio/templates/ingress-studio-api.yaml
@@ -37,7 +37,7 @@ spec:
     - http:
         paths:
           {{- if .Values.global.basePath }}
-          - path: /{{ include "studio.basePath" . }}/api
+          - path: /{{ include "studio.basePath" . }}/api(/|$)(.*)
           {{- else }}
           - path: /api
           {{- end }}

--- a/charts/studio/templates/ingress-studio-api.yaml
+++ b/charts/studio/templates/ingress-studio-api.yaml
@@ -13,7 +13,7 @@ apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
-  name: app-api
+  name: {{ .Release.Name }}-studio-api
   labels:
     {{- include "studio-ui.labels" . | nindent 4 }}
   annotations:

--- a/charts/studio/templates/ingress-studio-api.yaml
+++ b/charts/studio/templates/ingress-studio-api.yaml
@@ -13,11 +13,14 @@ apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
-  name: app
+  name: app-api
   labels:
     {{- include "studio-ui.labels" . | nindent 4 }}
-  {{- with .Values.global.ingress.annotations }}
   annotations:
+    {{- if .Values.global.basePath }}
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    {{- end }}
+  {{- with .Values.global.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
@@ -34,45 +37,9 @@ spec:
     - http:
         paths:
           {{- if .Values.global.basePath }}
-          - path: /{{ include "studio.basePath" . }}
-          {{- else }}
-          - path: /
-          {{- end }}
-            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
-            pathType: ImplementationSpecific
-            {{- end }}
-            backend:
-            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
-              service:
-                name: studio-ui
-                port:
-                  number: {{ .Values.studioUi.service.port }}
-              {{- else }}
-              serviceName: studio-ui
-              servicePort: {{ .Values.studioUi.service.port }}
-              {{- end }}
-          {{- if .Values.global.basePath }}
           - path: /{{ include "studio.basePath" . }}/api
           {{- else }}
           - path: /api
-          {{- end }}
-            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
-            pathType: ImplementationSpecific
-            {{- end }}
-            backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-              service:
-                name: studio-backend
-                port:
-                  number: {{ .Values.studioBackend.service.port }}
-              {{- else }}
-              serviceName: studio-backend
-              servicePort: {{ .Values.studioBackend.service.port }}
-              {{- end }}
-          {{- if .Values.global.basePath }}
-          - path: /{{ include "studio.basePath" . }}/webhook
-          {{- else }}
-          - path: /webhook
           {{- end }}
             {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
             pathType: ImplementationSpecific

--- a/charts/studio/templates/ingress-studio-api.yaml
+++ b/charts/studio/templates/ingress-studio-api.yaml
@@ -18,7 +18,7 @@ metadata:
     {{- include "studio-ui.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.global.basePath }}
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
     {{- end }}
   {{- with .Values.global.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
@@ -37,7 +37,7 @@ spec:
     - http:
         paths:
           {{- if .Values.global.basePath }}
-          - path: /{{ include "studio.basePath" . }}/api(/|$)(.*)
+          - path: /{{ include "studio.basePath" . }}/(api(?:/|$).*)
           {{- else }}
           - path: /api
           {{- end }}

--- a/charts/studio/templates/ingress-studio-ui.yaml
+++ b/charts/studio/templates/ingress-studio-ui.yaml
@@ -17,9 +17,6 @@ metadata:
   labels:
     {{- include "studio-ui.labels" . | nindent 4 }}
   annotations:
-    {{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
-    {{- end }}
   {{- with .Values.global.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/studio/templates/ingress-studio-ui.yaml
+++ b/charts/studio/templates/ingress-studio-ui.yaml
@@ -17,7 +17,7 @@ metadata:
   labels:
     {{- include "studio-ui.labels" . | nindent 4 }}
   annotations:
-    {{- if .Values.global.basePath }}
+    {{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     {{- end }}
   {{- with .Values.global.ingress.annotations }}
@@ -36,7 +36,7 @@ spec:
   rules:
     - http:
         paths:
-          {{- if .Values.global.basePath }}
+          {{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}
           - path: /{{ include "studio.basePath" . }}((?:/|$).*)
           {{- else }}
           - path: /

--- a/charts/studio/templates/ingress-studio-ui.yaml
+++ b/charts/studio/templates/ingress-studio-ui.yaml
@@ -37,7 +37,7 @@ spec:
     - http:
         paths:
           {{- if .Values.global.basePath }}
-          - path: /{{ include "studio.basePath" . }}
+          - path: /{{ include "studio.basePath" . }}(/|$)(.*)
           {{- else }}
           - path: /
           {{- end }}

--- a/charts/studio/templates/ingress-studio-ui.yaml
+++ b/charts/studio/templates/ingress-studio-ui.yaml
@@ -18,7 +18,7 @@ metadata:
     {{- include "studio-ui.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.global.basePath }}
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
     {{- end }}
   {{- with .Values.global.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
@@ -37,7 +37,7 @@ spec:
     - http:
         paths:
           {{- if .Values.global.basePath }}
-          - path: /{{ include "studio.basePath" . }}(/|$)(.*)
+          - path: /{{ include "studio.basePath" . }}((?:/|$).*)
           {{- else }}
           - path: /
           {{- end }}

--- a/charts/studio/templates/ingress-studio-ui.yaml
+++ b/charts/studio/templates/ingress-studio-ui.yaml
@@ -1,0 +1,60 @@
+{{- if .Values.global.ingress.enabled -}}
+{{- if and .Values.global.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.global.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.global.ingress.annotations "kubernetes.io/ingress.class" .Values.global.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: app-ui
+  labels:
+    {{- include "studio-ui.labels" . | nindent 4 }}
+  annotations:
+    {{- if .Values.global.basePath }}
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    {{- end }}
+  {{- with .Values.global.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.global.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.global.ingress.className }}
+  {{- end }}
+  {{- if and .Values.global.ingress.tlsEnabled .Values.global.ingress.hostnameEnabled }}
+  tls:
+    - hosts:
+        - {{ .Values.global.host }}
+      secretName: {{ .Values.global.ingress.tlsSecretName }}
+  {{- end }}
+  rules:
+    - http:
+        paths:
+          {{- if .Values.global.basePath }}
+          - path: /{{ include "studio.basePath" . }}
+          {{- else }}
+          - path: /
+          {{- end }}
+            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
+            pathType: ImplementationSpecific
+            {{- end }}
+            backend:
+            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: studio-ui
+                port:
+                  number: {{ .Values.studioUi.service.port }}
+              {{- else }}
+              serviceName: studio-ui
+              servicePort: {{ .Values.studioUi.service.port }}
+              {{- end }}
+      {{- if .Values.global.ingress.hostnameEnabled }}
+      host: {{ .Values.global.host }}
+      {{- end }}
+{{- end }}

--- a/charts/studio/templates/ingress-studio-ui.yaml
+++ b/charts/studio/templates/ingress-studio-ui.yaml
@@ -13,7 +13,7 @@ apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
-  name: app-ui
+  name: {{ .Release.Name }}-studio-ui
   labels:
     {{- include "studio-ui.labels" . | nindent 4 }}
   annotations:

--- a/charts/studio/templates/ingress-studio-webhook.yaml
+++ b/charts/studio/templates/ingress-studio-webhook.yaml
@@ -18,7 +18,7 @@ metadata:
     {{- include "studio-ui.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.global.basePath }}
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
     {{- end }}
   {{- with .Values.global.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
@@ -37,7 +37,7 @@ spec:
     - http:
         paths:
           {{- if .Values.global.basePath }}
-          - path: /{{ include "studio.basePath" . }}/webhook(/|$)(.*)
+          - path: /{{ include "studio.basePath" . }}/(webhook(?:/|$).*)
           {{- else }}
           - path: /webhook
           {{- end }}

--- a/charts/studio/templates/ingress-studio-webhook.yaml
+++ b/charts/studio/templates/ingress-studio-webhook.yaml
@@ -37,7 +37,7 @@ spec:
     - http:
         paths:
           {{- if .Values.global.basePath }}
-          - path: /{{ include "studio.basePath" . }}/webhook
+          - path: /{{ include "studio.basePath" . }}/webhook(/|$)(.*)
           {{- else }}
           - path: /webhook
           {{- end }}

--- a/charts/studio/templates/ingress-studio-webhook.yaml
+++ b/charts/studio/templates/ingress-studio-webhook.yaml
@@ -17,7 +17,7 @@ metadata:
   labels:
     {{- include "studio-ui.labels" . | nindent 4 }}
   annotations:
-    {{- if .Values.global.basePath }}
+    {{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     {{- end }}
   {{- with .Values.global.ingress.annotations }}
@@ -36,7 +36,7 @@ spec:
   rules:
     - http:
         paths:
-          {{- if .Values.global.basePath }}
+          {{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}
           - path: /{{ include "studio.basePath" . }}/(webhook(?:/|$).*)
           {{- else }}
           - path: /webhook

--- a/charts/studio/templates/ingress-studio-webhook.yaml
+++ b/charts/studio/templates/ingress-studio-webhook.yaml
@@ -13,7 +13,7 @@ apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
-  name: app-webhook
+  name: {{ .Release.Name }}-studio-webhook
   labels:
     {{- include "studio-ui.labels" . | nindent 4 }}
   annotations:

--- a/charts/studio/templates/ingress-studio-webhook.yaml
+++ b/charts/studio/templates/ingress-studio-webhook.yaml
@@ -1,0 +1,60 @@
+{{- if .Values.global.ingress.enabled -}}
+{{- if and .Values.global.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.global.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.global.ingress.annotations "kubernetes.io/ingress.class" .Values.global.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: app-webhook
+  labels:
+    {{- include "studio-ui.labels" . | nindent 4 }}
+  annotations:
+    {{- if .Values.global.basePath }}
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    {{- end }}
+  {{- with .Values.global.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.global.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.global.ingress.className }}
+  {{- end }}
+  {{- if and .Values.global.ingress.tlsEnabled .Values.global.ingress.hostnameEnabled }}
+  tls:
+    - hosts:
+        - {{ .Values.global.host }}
+      secretName: {{ .Values.global.ingress.tlsSecretName }}
+  {{- end }}
+  rules:
+    - http:
+        paths:
+          {{- if .Values.global.basePath }}
+          - path: /{{ include "studio.basePath" . }}/webhook
+          {{- else }}
+          - path: /webhook
+          {{- end }}
+            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
+            pathType: ImplementationSpecific
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: studio-backend
+                port:
+                  number: {{ .Values.studioBackend.service.port }}
+              {{- else }}
+              serviceName: studio-backend
+              servicePort: {{ .Values.studioBackend.service.port }}
+              {{- end }}
+      {{- if .Values.global.ingress.hostnameEnabled }}
+      host: {{ .Values.global.host }}
+      {{- end }}
+{{- end }}

--- a/charts/studio/templates/ingress-studio.yaml
+++ b/charts/studio/templates/ingress-studio.yaml
@@ -34,7 +34,7 @@ spec:
     - http:
         paths:
           {{- if .Values.global.basePath }}
-          - path: /{{ .Values.global.basePath | trimPrefix "/" | trimSuffix "/" }}/
+          - path: /{{ .Values.global.basePath | trimPrefix "/" | trimSuffix "/" }}
           {{- else }}
           - path: /
           {{- end }}

--- a/charts/studio/templates/ingress-studio.yaml
+++ b/charts/studio/templates/ingress-studio.yaml
@@ -34,7 +34,7 @@ spec:
     - http:
         paths:
           {{- if .Values.global.basePath }}
-          - path: /{{ .Values.global.basePath | trimPrefix "/" | trimSuffix "/" }}
+          - path: /{{ include "studio.basePath" . }}
           {{- else }}
           - path: /
           {{- end }}
@@ -52,7 +52,7 @@ spec:
               servicePort: {{ .Values.studioUi.service.port }}
               {{- end }}
           {{- if .Values.global.basePath }}
-          - path: /{{ .Values.global.basePath | trimPrefix "/" | trimSuffix "/" }}/api
+          - path: /{{ include "studio.basePath" . }}/api
           {{- else }}
           - path: /api
           {{- end }}
@@ -70,7 +70,7 @@ spec:
               servicePort: {{ .Values.studioBackend.service.port }}
               {{- end }}
           {{- if .Values.global.basePath }}
-          - path: /{{ .Values.global.basePath | trimPrefix "/" | trimSuffix "/" }}/webhook
+          - path: /{{ include "studio.basePath" . }}/webhook
           {{- else }}
           - path: /webhook
           {{- end }}

--- a/charts/studio/templates/ingress-studio.yaml
+++ b/charts/studio/templates/ingress-studio.yaml
@@ -33,7 +33,11 @@ spec:
   rules:
     - http:
         paths:
+          {{- if .Values.global.basePath }}
+          - path: /{{ .Values.global.basePath | trimPrefix "/" | trimSuffix "/" }}/
+          {{- else }}
           - path: /
+          {{- end }}
             {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
             pathType: ImplementationSpecific
             {{- end }}
@@ -47,7 +51,11 @@ spec:
               serviceName: studio-ui
               servicePort: {{ .Values.studioUi.service.port }}
               {{- end }}
+          {{- if .Values.global.basePath }}
+          - path: /{{ .Values.global.basePath | trimPrefix "/" | trimSuffix "/" }}/api
+          {{- else }}
           - path: /api
+          {{- end }}
             {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
             pathType: ImplementationSpecific
             {{- end }}
@@ -61,7 +69,11 @@ spec:
               serviceName: studio-backend
               servicePort: {{ .Values.studioBackend.service.port }}
               {{- end }}
+          {{- if .Values.global.basePath }}
+          - path: /{{ .Values.global.basePath | trimPrefix "/" | trimSuffix "/" }}/webhook
+          {{- else }}
           - path: /webhook
+          {{- end }}
             {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
             pathType: ImplementationSpecific
             {{- end }}

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -8,6 +8,8 @@ imagePullSecrets: []
 global:
   # -- Studio: Hostname for accessing Studio (no http(s) scheme)
   host: "studio.example.com"
+  # -- Studio: Base path (prefix)
+  basePath: ""
   # -- Studio: Maximum number of views
   maxViews: "100"
   # -- Studio: Maximum number of teams


### PR DESCRIPTION
This PR adds support for configuring the base path of a Studio deployment via the `global.basePath` variable. This is useful when you want to deploy Studio on a subdirectory path. 

Closes https://github.com/iterative/helm-charts/issues/84