### PR TITLE
Add support for setting blobvault PV accessModes

### DIFF
--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.27
+version: 0.1.28
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/studio/templates/persistentvolume.yaml
+++ b/charts/studio/templates/persistentvolume.yaml
@@ -5,7 +5,9 @@ metadata:
   name: blobvault
 spec:
   accessModes:
-    - ReadWriteOnce
+  {{- with .Values.global.blobvault.persistentVolume.accessModes }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
   storageClassName: {{ .Values.global.blobvault.persistentVolume.storageClassName }}
   resources:
     requests:

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -35,6 +35,8 @@ global:
   blobvault:
     # -- Blobvault local backing store size
     persistentVolume:
+      accessModes: 
+        - ReadWriteOnce
       storageClassName: local-path
       size: 30Gi
 


### PR DESCRIPTION
We'd hardcoded the blobvault PersistentVolume's access mode by accident. This should be configurable as it is dependent on the volume plugin/CSI.