### PR TITLE
Fix(ingress): Add hooks to ingress recources to fix the issue with paths conflict

### DIFF
--- a/charts/studio/templates/ingress-blobvault.yaml
+++ b/charts/studio/templates/ingress-blobvault.yaml
@@ -15,6 +15,7 @@ kind: Ingress
 metadata:
   name: blobvault
   annotations:
+    helm.sh/hook: post-install,post-upgrade
     nginx.ingress.kubernetes.io/rewrite-target: /$2
   {{- with .Values.global.ingress.annotations }}
     {{- toYaml . | nindent 4 }}

--- a/charts/studio/templates/ingress-studio-api.yaml
+++ b/charts/studio/templates/ingress-studio-api.yaml
@@ -17,6 +17,7 @@ metadata:
   labels:
     {{- include "studio-ui.labels" . | nindent 4 }}
   annotations:
+    helm.sh/hook: post-install,post-upgrade
     {{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     {{- end }}

--- a/charts/studio/templates/ingress-studio-ui.yaml
+++ b/charts/studio/templates/ingress-studio-ui.yaml
@@ -17,6 +17,7 @@ metadata:
   labels:
     {{- include "studio-ui.labels" . | nindent 4 }}
   annotations:
+    helm.sh/hook: post-install,post-upgrade
   {{- with .Values.global.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/studio/templates/ingress-studio-webhook.yaml
+++ b/charts/studio/templates/ingress-studio-webhook.yaml
@@ -17,6 +17,7 @@ metadata:
   labels:
     {{- include "studio-ui.labels" . | nindent 4 }}
   annotations:
+    helm.sh/hook: post-install,post-upgrade
     {{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     {{- end }}


### PR DESCRIPTION
Fixes https://github.com/iterative/itops/issues/1356

This PR adds the helm hook definition to run the upgrade after the successful process. This allows to fix the issue which we introduced in [Studio 0.1.27](https://github.com/iterative/helm-charts/releases/tag/studio-0.1.27), by splitting the ingress resources