### PR TITLE
fix(migrations): Move django migration to init-containers and fix phonenumber migration

### DIFF
--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.30
+version: 0.1.31
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -24,7 +24,7 @@ version: 0.1.31
 appVersion: "v1.82.0"
 
 maintainers:
-  - name: Iterative, Inc.
+  - name: iterative
     email: support@iterative.ai
 
 dependencies:

--- a/charts/studio/templates/deployment-studio-backend.yaml
+++ b/charts/studio/templates/deployment-studio-backend.yaml
@@ -8,6 +8,10 @@ spec:
   {{- if not .Values.studioBackend.autoscaling.enabled }}
   replicas: {{ .Values.studioBackend.replicaCount }}
   {{- end }}
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 50%
   selector:
     matchLabels:
       {{- include "studio-backend.selectorLabels" . | nindent 6 }}
@@ -28,6 +32,26 @@ spec:
       serviceAccountName: {{ include "studio.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.studioBackend.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: run-migrations
+          securityContext: {{- toYaml .Values.studioBackend.securityContext | nindent 12 }}
+          image: "{{ .Values.studioBackend.image.repository }}:{{ .Values.studioBackend.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.studioBackend.image.pullPolicy }}
+          command: [ "/bin/sh", "-c" ]
+          args:
+            - |
+              ./manage.py migrate
+          {{- if .Release.IsUpgrade }}
+              ./manage.py migrate phonenumber --fake-initial
+              ./manage.py migrate
+          {{- end }}
+          envFrom:
+            - configMapRef:
+                name: studio
+            - configMapRef:
+                name: studio-backend
+            - secretRef:
+                name: studio
       containers:
         - name: studio-backend
           securityContext:
@@ -52,7 +76,16 @@ spec:
               path: /health?format=json
               port: 8000
             initialDelaySeconds: 5
-            periodSeconds: 25
+            periodSeconds: 5
+            failureThreshold: 3
+            timeoutSeconds: 60
+          livenessProbe:
+            httpGet:
+              path: /health?format=json
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 5
             timeoutSeconds: 60
           {{- if .Values.global.customCaCert }}
           volumeMounts:
@@ -61,6 +94,11 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.studioBackend.resources | nindent 12 }}
+          env:
+            - name: "NO_MIGRATE_DB"
+              value: "1"
+            - name: "WAIT_FOR_MIGRATIONS"
+              value: "1"
           envFrom:
             - configMapRef:
                 name: studio

--- a/charts/studio/templates/deployment-studio-ui.yaml
+++ b/charts/studio/templates/deployment-studio-ui.yaml
@@ -8,6 +8,10 @@ spec:
   {{- if not .Values.studioUi.autoscaling.enabled }}
   replicas: {{ .Values.studioUi.replicaCount }}
   {{- end }}
+  strategy:
+    rollingUpdate:
+      maxSurge: 50%
+      maxUnavailable: 0
   selector:
     matchLabels:
       {{- include "studio-ui.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
Also, handle the phone number fake migration if the Studio is being upgraded

I was testing this in two scenarios:
 1. by plain install `helm upgrade -i studio . -n studio --create-namespace --values values.yaml --debug --create-namespace`
 2. By installing old chart, and upgrading ```bash helm upgrade -i studio iterative/studio -n studio --version 0.1.25 --create-namespace --values values.yaml --wait helm upgrade -i studio . -n studio --create-namespace --values values.yaml --debug --create-namespace ```

Marks this as a draft until merging workflow from for #101  