### PR TITLE
feature(values): Extract webook URL Outside the SCM definitions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v3
         with:
-          version: v3.12.0
+          version: v3.12.2
 
       - uses: actions/setup-python@v4
         with:
@@ -58,3 +58,22 @@ jobs:
         run: |
           ct lint-and-install --target-branch ${{ github.event.repository.default_branch }} --upgrade --debug \
           --helm-extra-set-args '--set ci=true --set global.blobvault.persistentVolume.storageClassName="standard" --set imagePullSecrets[0].name=iterativeai --set dockerUsername=${{ secrets.ITERATIVE_DOCKER_REGISTRY_USER }} --set dockerPassword=${{ secrets.ITERATIVE_DOCKER_REGISTRY_PASSWORD }} --set dockerServer=docker.iterative.ai'
+
+  helm-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.12.2
+
+      - name: Run helm-docs
+        working-directory: charts/studio/
+        run: |
+          docker run --pull always --rm --volume "$(pwd):/helm-docs" -u $(id -u) jnorwood/helm-docs:latest
+          git diff --exit-code

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,7 @@ name: Lint and Test Charts
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - main

--- a/README.md
+++ b/README.md
@@ -125,7 +125,6 @@ global:
       appName: "iterative-studio-selfhosted"
       clientId: "<gh-client-id>"
       clientSecret: "<gh-app-secret>"
-      webhookUrl: "https://my-studio.private.com/webhook/github"
       privateKey: |-
         -----BEGIN RSA PRIVATE KEY-----
         ...

--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.7
+version: 0.2.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/studio/README.md
+++ b/charts/studio/README.md
@@ -1,6 +1,6 @@
 # studio
 
-![Version: 0.1.32](https://img.shields.io/badge/Version-0.1.32-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.82.0](https://img.shields.io/badge/AppVersion-v1.82.0-informational?style=flat-square)
+![Version: 0.2.8](https://img.shields.io/badge/Version-0.2.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.9.1](https://img.shields.io/badge/AppVersion-v2.9.1-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -16,7 +16,7 @@ A Helm chart for Kubernetes
 |------------|------|---------|
 | https://charts.bitnami.com/bitnami | nginx | 13.2.30 |
 | https://charts.bitnami.com/bitnami | postgresql | 11.9.13 |
-| https://charts.bitnami.com/bitnami | redis | 17.2.0 |
+| https://charts.bitnami.com/bitnami | redis | 17.11.8 |
 
 ## Values
 
@@ -31,7 +31,9 @@ A Helm chart for Kubernetes
 | global.blobvault.secretAccessKeyId | string | `""` | Blobvault S3 secret access key ID |
 | global.celery.brokerUrl | string | `""` | Celery broker URL |
 | global.celery.resultBackend | string | `""` | Celery result URL |
-| global.customCaCert | string | `""` | Studio: Custom CA certificate in PEM format customCaCert: |-   -----BEGIN CERTIFICATE-----   ....   -----END CERTIFICATE-----  |
+| global.customCaCert | DEPRECATED | `""` | Studio: Custom CA certificate in PEM format Deprecated in favor of `customCaCerts` customCaCert: |-   -----BEGIN CERTIFICATE-----   ....   -----END CERTIFICATE-----  |
+| global.customCaCerts | list | `[]` | Studio: Custom CA certificate in PEM format customCaCerts: - |-     -----BEGIN CERTIFICATE-----     ....     -----END CERTIFICATE-----  |
+| global.dvcx | object | `{}` | Studio: Settings related to DVCX |
 | global.envVars | object | `{}` | Studio: Additional environment variables for all pods |
 | global.host | string | `"studio.example.com"` | Studio: Hostname for accessing Studio (no http(s) scheme) |
 | global.ingress.annotations | object | `{}` |  |
@@ -42,16 +44,22 @@ A Helm chart for Kubernetes
 | global.ingress.tlsSecretName | string | `"chart-example-tls"` |  |
 | global.maxTeams | string | `"10"` | Studio: Maximum number of teams |
 | global.maxViews | string | `"100"` | Studio: Maximum number of views |
-| global.postgres.databasePassword | string | `"postgres"` | Postgres database password |
-| global.postgres.databaseUrl | string | `"studio-postgresql:5432/iterativeai"` | Postgres database URL |
-| global.postgres.databaseUser | string | `"postgres"` | Postgres database user |
-| global.scmProviders.bitbucket | object | `{"apiUrl":"","clientId":"","enabled":false,"secretKey":"","url":""}` | Configure BitBucket App integration with the Studio. |
+| global.postgres.databaseName | string | `"iterativeai"` | Postgres database name |
+| global.postgres.databasePassword | DEPRECATED | `""` | Postgres database password |
+| global.postgres.databaseUrl | DEPRECATED | `""` | Postgres database URL |
+| global.postgres.databaseUser | DEPRECATED | `""` | Postgres database user |
+| global.postgres.host | string | `"studio-postgresql"` | Postgres hostname |
+| global.postgres.password | string | `"postgres"` | Postgres password |
+| global.postgres.port | string | `"5432"` | Postgres port |
+| global.postgres.user | string | `"postgres"` | Postgres user |
+| global.scmProviders.bitbucket | object | `{"apiUrl":"","clientId":"","enabled":false,"secretKey":"","url":"","webhookUrl":""}` | BitBucket App integration with Studio. |
 | global.scmProviders.bitbucket.apiUrl | string | `""` | Bitbucket Server API URL Set this if you're using the selfhosted version |
 | global.scmProviders.bitbucket.clientId | string | `""` | Bitbucket OAuth App Client ID |
 | global.scmProviders.bitbucket.enabled | bool | `false` | Bitbucket enabled |
 | global.scmProviders.bitbucket.secretKey | string | `""` | Bitbucket OAuth App Secret Key |
 | global.scmProviders.bitbucket.url | string | `""` | Bitbucket Server URL Set this if you're using the selfhosted version |
-| global.scmProviders.github | object | `{"apiUrl":"","appId":"","appName":"","clientId":"","clientSecret":"","enabled":false,"privateKey":"","url":""}` | Configure GitHub App integration with the Studio. |
+| global.scmProviders.bitbucket.webhookUrl | DEPRECATED | `""` | BitBucket Webhook URL |
+| global.scmProviders.github | object | `{"apiUrl":"","appId":"","appName":"","clientId":"","clientSecret":"","enabled":false,"privateKey":"","url":"","webhookUrl":""}` | GitHub App integration with Studio. |
 | global.scmProviders.github.apiUrl | string | `""` | GitHub Enterprise API URL Set this if you're using the selfhosted version |
 | global.scmProviders.github.appId | string | `""` | GitHub OAuth App ID |
 | global.scmProviders.github.appName | string | `""` | GitHub OAuth App Name |
@@ -60,13 +68,15 @@ A Helm chart for Kubernetes
 | global.scmProviders.github.enabled | bool | `false` | GitHub enabled |
 | global.scmProviders.github.privateKey | string | `""` | GitHub OAuth App Private Key |
 | global.scmProviders.github.url | string | `""` | GitHub Enterprise URL Set this if you're using the selfhosted version |
-| global.scmProviders.gitlab | object | `{"clientId":"","enabled":false,"secretKey":"","url":"","webhookSecret":""}` | Configure GitLab App integration with the Studio. |
+| global.scmProviders.github.webhookUrl | DEPRECATED | `""` | GitHub Webhook URL |
+| global.scmProviders.gitlab | object | `{"clientId":"","enabled":false,"secretKey":"","url":"","webhookSecret":"","webhookUrl":""}` | GitLab App integration with Studio. |
 | global.scmProviders.gitlab.clientId | string | `""` | GitLab OAuth App Client ID |
 | global.scmProviders.gitlab.enabled | bool | `false` | GitLab enabled |
 | global.scmProviders.gitlab.secretKey | string | `""` | GitLab OAuth App Secret Key |
 | global.scmProviders.gitlab.url | string | `""` | GitLab Enterprise Edition URL Set this if you're using the selfhosted version |
 | global.scmProviders.gitlab.webhookSecret | string | `""` | GitLab Webhook Secret |
-| global.scmProviders.webhookHost | string | `$global.host` value. | Set custom hostname for incoming webhook  if you're using SaaS version of GitHub, GitLab or Bitbucket. |
+| global.scmProviders.gitlab.webhookUrl | DEPRECATED | `""` | GitLab Webhook URL |
+| global.scmProviders.webhookHost | string | `$global.host` value. | Custom hostname for incoming webhook (if Studio runs on a private network and you use SaaS versions of GitHub, GitLab, or Bitbucket) |
 | global.secretKey | string | `""` | Studio: Secret key for signing Webhook payloads We recommend you set this externally. If left empty, a random key will be generated. |
 | imagePullSecrets | list | `[]` | Secret containing Docker registry credentials |
 | nginx.extraVolumeMounts[0].mountPath | string | `"/blobvault"` |  |
@@ -80,9 +90,18 @@ A Helm chart for Kubernetes
 | postgresql.fullnameOverride | string | `"studio-postgresql"` | Postgres name override |
 | postgresql.global.postgresql.auth.database | string | `"iterativeai"` | Postgres database |
 | postgresql.global.postgresql.auth.postgresPassword | string | `"postgres"` | Postgres password |
-| redis.auth.enabled | bool | `false` | Redis authentication enabled |
+| redis.auth | object | `{"enabled":false}` | Redis authentication settings |
+| redis.auth.enabled | bool | `false` | Redis authentication disabled |
+| redis.commonConfiguration | string | `"timeout 20"` | Redis common configuration to be added into the ConfigMap |
 | redis.enabled | bool | `true` | Redis enabled |
 | redis.fullnameOverride | string | `"studio-redis"` | Redis name override |
+| redis.master | object | `{"persistence":{"enabled":false},"resources":{"limits":{"cpu":"1000m","memory":"2Gi"},"requests":{"cpu":"200m","memory":"512Mi"}}}` | Redis master configuration |
+| redis.master.persistence | object | `{"enabled":false}` | Redis master persistence configuration |
+| redis.master.persistence.enabled | bool | `false` | Redis master persistence is disabled |
+| redis.replica | object | `{"persistence":{"enabled":false},"replicaCount":0}` | Redis replica configuration |
+| redis.replica.persistence | object | `{"enabled":false}` | Redis replica persistence configuration |
+| redis.replica.persistence.enabled | bool | `false` | Redis replica persistence is disabled |
+| redis.replica.replicaCount | int | `0` | Redis replica count. 0 for standalone deployment of 1 master and 0 replicas |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `false` |  |
 | serviceAccount.name | string | `""` |  |

--- a/charts/studio/README.md
+++ b/charts/studio/README.md
@@ -1,0 +1,171 @@
+# studio
+
+![Version: 0.1.32](https://img.shields.io/badge/Version-0.1.32-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.82.0](https://img.shields.io/badge/AppVersion-v1.82.0-informational?style=flat-square)
+
+A Helm chart for Kubernetes
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| iterative | <support@iterative.ai> |  |
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://charts.bitnami.com/bitnami | nginx | 13.2.30 |
+| https://charts.bitnami.com/bitnami | postgresql | 11.9.13 |
+| https://charts.bitnami.com/bitnami | redis | 17.2.0 |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| global.basePath | string | `""` | Studio: Base path (prefix) |
+| global.blobvault.accessKeyId | string | `""` | Blobvault S3 access key ID |
+| global.blobvault.bucket | string | `""` | Blobvault S3 bucket name |
+| global.blobvault.endpointUrl | string | `""` | Blobvault S3 endpoint URL |
+| global.blobvault.persistentVolume | object | `{"accessModes":["ReadWriteOnce"],"size":"30Gi","storageClassName":"local-path"}` | Blobvault local backing store size |
+| global.blobvault.regionName | string | `""` | Blobvault S3 region |
+| global.blobvault.secretAccessKeyId | string | `""` | Blobvault S3 secret access key ID |
+| global.celery.brokerUrl | string | `""` | Celery broker URL |
+| global.celery.resultBackend | string | `""` | Celery result URL |
+| global.customCaCert | string | `""` | Studio: Custom CA certificate in PEM format customCaCert: |-   -----BEGIN CERTIFICATE-----   ....   -----END CERTIFICATE-----  |
+| global.envVars | object | `{}` | Studio: Additional environment variables for all pods |
+| global.host | string | `"studio.example.com"` | Studio: Hostname for accessing Studio (no http(s) scheme) |
+| global.ingress.annotations | object | `{}` |  |
+| global.ingress.className | string | `""` |  |
+| global.ingress.enabled | bool | `true` |  |
+| global.ingress.hostnameEnabled | bool | `true` |  |
+| global.ingress.tlsEnabled | bool | `false` |  |
+| global.ingress.tlsSecretName | string | `"chart-example-tls"` |  |
+| global.maxTeams | string | `"10"` | Studio: Maximum number of teams |
+| global.maxViews | string | `"100"` | Studio: Maximum number of views |
+| global.postgres.databasePassword | string | `"postgres"` | Postgres database password |
+| global.postgres.databaseUrl | string | `"studio-postgresql:5432/iterativeai"` | Postgres database URL |
+| global.postgres.databaseUser | string | `"postgres"` | Postgres database user |
+| global.scmProviders.bitbucket | object | `{"apiUrl":"","clientId":"","enabled":false,"secretKey":"","url":""}` | Configure BitBucket App integration with the Studio. |
+| global.scmProviders.bitbucket.apiUrl | string | `""` | Bitbucket Server API URL Set this if you're using the selfhosted version |
+| global.scmProviders.bitbucket.clientId | string | `""` | Bitbucket OAuth App Client ID |
+| global.scmProviders.bitbucket.enabled | bool | `false` | Bitbucket enabled |
+| global.scmProviders.bitbucket.secretKey | string | `""` | Bitbucket OAuth App Secret Key |
+| global.scmProviders.bitbucket.url | string | `""` | Bitbucket Server URL Set this if you're using the selfhosted version |
+| global.scmProviders.github | object | `{"apiUrl":"","appId":"","appName":"","clientId":"","clientSecret":"","enabled":false,"privateKey":"","url":""}` | Configure GitHub App integration with the Studio. |
+| global.scmProviders.github.apiUrl | string | `""` | GitHub Enterprise API URL Set this if you're using the selfhosted version |
+| global.scmProviders.github.appId | string | `""` | GitHub OAuth App ID |
+| global.scmProviders.github.appName | string | `""` | GitHub OAuth App Name |
+| global.scmProviders.github.clientId | string | `""` | GitHub OAuth App Client ID |
+| global.scmProviders.github.clientSecret | string | `""` | GitHub OAuth App Secret |
+| global.scmProviders.github.enabled | bool | `false` | GitHub enabled |
+| global.scmProviders.github.privateKey | string | `""` | GitHub OAuth App Private Key |
+| global.scmProviders.github.url | string | `""` | GitHub Enterprise URL Set this if you're using the selfhosted version |
+| global.scmProviders.gitlab | object | `{"clientId":"","enabled":false,"secretKey":"","url":"","webhookSecret":""}` | Configure GitLab App integration with the Studio. |
+| global.scmProviders.gitlab.clientId | string | `""` | GitLab OAuth App Client ID |
+| global.scmProviders.gitlab.enabled | bool | `false` | GitLab enabled |
+| global.scmProviders.gitlab.secretKey | string | `""` | GitLab OAuth App Secret Key |
+| global.scmProviders.gitlab.url | string | `""` | GitLab Enterprise Edition URL Set this if you're using the selfhosted version |
+| global.scmProviders.gitlab.webhookSecret | string | `""` | GitLab Webhook Secret |
+| global.scmProviders.webhookHost | string | `$global.host` value. | Set custom hostname for incoming webhook  if you're using SaaS version of GitHub, GitLab or Bitbucket. |
+| global.secretKey | string | `""` | Studio: Secret key for signing Webhook payloads We recommend you set this externally. If left empty, a random key will be generated. |
+| imagePullSecrets | list | `[]` | Secret containing Docker registry credentials |
+| nginx.extraVolumeMounts[0].mountPath | string | `"/blobvault"` |  |
+| nginx.extraVolumeMounts[0].name | string | `"blobvault"` |  |
+| nginx.extraVolumes[0].name | string | `"blobvault"` |  |
+| nginx.extraVolumes[0].persistentVolumeClaim.claimName | string | `"blobvault"` |  |
+| nginx.ingress.enabled | bool | `false` |  |
+| nginx.serverBlock | string | `"server {\n    listen       8080;\n    server_name  _;\n\n    root /blobvault;\n\n    location ~ \\.gz$ {\n        if ($request_method = 'OPTIONS') {\n            add_header 'Access-Control-Allow-Origin' '*';\n            #\n            # Cookies\n            #\n            add_header 'Access-Control-Allow-Credentials' 'true';\n            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';\n            #\n            # Custom headers and headers various browsers *should* be OK with but aren't\n            #\n            add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,X-Studio-Trace-Id';\n            #\n            # Tell client that this pre-flight info is valid for 20 days\n            #\n            add_header 'Access-Control-Max-Age' 1728000;\n            add_header 'Content-Type' 'text/plain charset=UTF-8';\n            add_header 'Content-Length' 0;\n            return 204;\n        }\n        if ($request_method = 'GET') {\n            add_header 'Access-Control-Allow-Origin' '*';\n            add_header 'Access-Control-Allow-Credentials' 'true';\n            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';\n            add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,X-Studio-Trace-Id';\n            add_header Content-Encoding gzip;\n        }\n        gzip off;\n        types { } default_type \"application/json\";\n    }\n\n\n    location / {\n        if ($request_method = 'OPTIONS') {\n            add_header 'Access-Control-Allow-Origin' '*';\n            #\n            # Cookies\n            #\n            add_header 'Access-Control-Allow-Credentials' 'true';\n            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';\n            #\n            # Custom headers and headers various browsers *should* be OK with but aren't\n            #\n            add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,X-Studio-Trace-Id';\n            #\n            # Tell client that this pre-flight info is valid for 20 days\n            #\n            add_header 'Access-Control-Max-Age' 1728000;\n            add_header 'Content-Type' 'text/plain charset=UTF-8';\n            add_header 'Content-Length' 0;\n            return 204;\n        }\n        if ($request_method = 'GET') {\n            add_header 'Access-Control-Allow-Origin' '*';\n            add_header 'Access-Control-Allow-Credentials' 'true';\n            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';\n            add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,X-Studio-Trace-Id';\n        }\n\n        try_files $uri $uri/ =404;\n    }\n}"` |  |
+| nginx.service.type | string | `"ClusterIP"` |  |
+| postgresql.enabled | bool | `true` | Postgres enabled |
+| postgresql.fullnameOverride | string | `"studio-postgresql"` | Postgres name override |
+| postgresql.global.postgresql.auth.database | string | `"iterativeai"` | Postgres database |
+| postgresql.global.postgresql.auth.postgresPassword | string | `"postgres"` | Postgres password |
+| redis.auth.enabled | bool | `false` | Redis authentication enabled |
+| redis.enabled | bool | `true` | Redis enabled |
+| redis.fullnameOverride | string | `"studio-redis"` | Redis name override |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.create | bool | `false` |  |
+| serviceAccount.name | string | `""` |  |
+| studioBackend.affinity | object | `{}` |  |
+| studioBackend.autoscaling.enabled | bool | `false` |  |
+| studioBackend.autoscaling.maxReplicas | int | `5` |  |
+| studioBackend.autoscaling.minReplicas | int | `1` |  |
+| studioBackend.autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| studioBackend.envVars | object | `{}` | Studio: Additional environment variables for backend pods |
+| studioBackend.fullnameOverride | string | `""` |  |
+| studioBackend.image.pullPolicy | string | `"IfNotPresent"` |  |
+| studioBackend.image.repository | string | `"docker.iterative.ai/viewer_backend"` |  |
+| studioBackend.nameOverride | string | `""` |  |
+| studioBackend.nodeSelector | object | `{}` |  |
+| studioBackend.podAnnotations | object | `{}` |  |
+| studioBackend.podSecurityContext | object | `{}` |  |
+| studioBackend.replicaCount | int | `1` |  |
+| studioBackend.resources.limits.cpu | string | `"1000m"` |  |
+| studioBackend.resources.limits.memory | string | `"2Gi"` |  |
+| studioBackend.resources.requests.cpu | string | `"500m"` |  |
+| studioBackend.resources.requests.memory | string | `"1Gi"` |  |
+| studioBackend.securityContext | object | `{}` |  |
+| studioBackend.service.port | int | `8000` |  |
+| studioBackend.service.type | string | `"ClusterIP"` |  |
+| studioBackend.tolerations | list | `[]` |  |
+| studioBeat.affinity | object | `{}` |  |
+| studioBeat.autoscaling.enabled | bool | `false` |  |
+| studioBeat.autoscaling.maxReplicas | int | `5` |  |
+| studioBeat.autoscaling.minReplicas | int | `1` |  |
+| studioBeat.autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| studioBeat.envVars | object | `{}` | Studio: Additional environment variables for beat pods |
+| studioBeat.fullnameOverride | string | `""` |  |
+| studioBeat.nameOverride | string | `""` |  |
+| studioBeat.nodeSelector | object | `{}` |  |
+| studioBeat.podAnnotations | object | `{}` |  |
+| studioBeat.podSecurityContext | object | `{}` |  |
+| studioBeat.replicaCount | int | `1` |  |
+| studioBeat.resources.limits.cpu | string | `"200m"` |  |
+| studioBeat.resources.limits.memory | string | `"256Mi"` |  |
+| studioBeat.resources.requests.cpu | string | `"100m"` |  |
+| studioBeat.resources.requests.memory | string | `"128Mi"` |  |
+| studioBeat.securityContext | object | `{}` |  |
+| studioBeat.tolerations | list | `[]` |  |
+| studioUi.affinity | object | `{}` |  |
+| studioUi.autoscaling.enabled | bool | `false` |  |
+| studioUi.autoscaling.maxReplicas | int | `5` |  |
+| studioUi.autoscaling.minReplicas | int | `1` |  |
+| studioUi.autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| studioUi.envVars | object | `{}` | Studio: Additional environment variables for ui pods |
+| studioUi.fullnameOverride | string | `""` |  |
+| studioUi.image.pullPolicy | string | `"IfNotPresent"` |  |
+| studioUi.image.repository | string | `"docker.iterative.ai/viewer_ui"` |  |
+| studioUi.nameOverride | string | `""` |  |
+| studioUi.nodeSelector | object | `{}` |  |
+| studioUi.podAnnotations | object | `{}` |  |
+| studioUi.podSecurityContext | object | `{}` |  |
+| studioUi.replicaCount | int | `1` |  |
+| studioUi.resources.limits.cpu | string | `"1000m"` |  |
+| studioUi.resources.limits.memory | string | `"2Gi"` |  |
+| studioUi.resources.requests.cpu | string | `"500m"` |  |
+| studioUi.resources.requests.memory | string | `"1Gi"` |  |
+| studioUi.securityContext | object | `{}` |  |
+| studioUi.service.port | int | `3000` |  |
+| studioUi.service.type | string | `"ClusterIP"` |  |
+| studioUi.tolerations | list | `[]` |  |
+| studioWorker.affinity | object | `{}` |  |
+| studioWorker.autoscaling.enabled | bool | `false` |  |
+| studioWorker.autoscaling.maxReplicas | int | `5` |  |
+| studioWorker.autoscaling.minReplicas | int | `1` |  |
+| studioWorker.autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| studioWorker.envVars | object | `{}` | Studio: Additional environment variables for worker pods |
+| studioWorker.fullnameOverride | string | `""` |  |
+| studioWorker.nameOverride | string | `""` |  |
+| studioWorker.nodeSelector | object | `{}` |  |
+| studioWorker.podAnnotations | object | `{}` |  |
+| studioWorker.podSecurityContext | object | `{}` |  |
+| studioWorker.replicaCount | int | `1` |  |
+| studioWorker.resources.limits.cpu | string | `"1000m"` |  |
+| studioWorker.resources.limits.memory | string | `"1Gi"` |  |
+| studioWorker.resources.requests.cpu | string | `"500m"` |  |
+| studioWorker.resources.requests.memory | string | `"512Mi"` |  |
+| studioWorker.securityContext | object | `{}` |  |
+| studioWorker.tolerations | list | `[]` |  |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.11.0](https://github.com/norwoodj/helm-docs/releases/v1.11.0)

--- a/charts/studio/templates/configmap-studio.yaml
+++ b/charts/studio/templates/configmap-studio.yaml
@@ -21,8 +21,8 @@ data:
   {{- if .Values.global.scmProviders.bitbucket.apiUrl }}
   BITBUCKET_API_URL: {{ .Values.global.scmProviders.bitbucket.apiUrl | quote}}
   {{- end }}
-  {{- if .Values.global.scmProviders.bitbucket.webhookUrl }}
-  BITBUCKET_WEBHOOK_URL: {{ .Values.global.scmProviders.bitbucket.webhookUrl | quote}}
+  {{- if and .Values.global.scmProviders.bitbucket.enabled .Values.global.scmProviders.webhookHost }}
+  BITBUCKET_WEBHOOK_URL: "http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{ .Values.global.scmProviders.webhookHost}}/webhook/bitbucket/"
   {{- end }}
 
   ENABLE_BLOBVAULT: "True"
@@ -67,8 +67,8 @@ data:
   {{- if .Values.global.scmProviders.github.url }}
   GITHUB_URL: {{ .Values.global.scmProviders.github.url | quote }}
   {{- end }}
-  {{- if .Values.global.scmProviders.github.webhookUrl }}
-  GITHUB_WEBHOOK_URL: {{ .Values.global.scmProviders.github.webhookUrl | quote }}
+  {{- if and .Values.global.scmProviders.github.enabled .Values.global.scmProviders.webhookHost }}
+  GITHUB_WEBHOOK_URL: "http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{ .Values.global.scmProviders.webhookHost}}/webhook/github/"
   {{- end }}
   {{- if .Values.global.scmProviders.github.clientId }}
   GITHUB_APP_CLIENT_ID: {{ .Values.global.scmProviders.github.clientId | quote }}
@@ -83,8 +83,8 @@ data:
   {{- if .Values.global.scmProviders.gitlab.url }}
   GITLAB_URL: {{ .Values.global.scmProviders.gitlab.url | quote}}
   {{- end }}
-  {{- if .Values.global.scmProviders.gitlab.webhookUrl }}
-  GITLAB_WEBHOOK_URL: {{ .Values.global.scmProviders.gitlab.webhookUrl | quote }}
+  {{- if and .Values.global.scmProviders.gitlab.enabled .Values.global.scmProviders.webhookHost }}
+  GITLAB_WEBHOOK_URL: "http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{ .Values.global.scmProviders.webhookHost}}/webhook/gitlab/"
   {{- end }}
 
   {{- if .Values.global.maxViews }}

--- a/charts/studio/templates/configmap-studio.yaml
+++ b/charts/studio/templates/configmap-studio.yaml
@@ -1,3 +1,4 @@
+{{$webhookHost := .Values.global.scmProviders.webhookHost | default .Values.global.host }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -21,8 +22,8 @@ data:
   {{- if .Values.global.scmProviders.bitbucket.apiUrl }}
   BITBUCKET_API_URL: {{ .Values.global.scmProviders.bitbucket.apiUrl | quote}}
   {{- end }}
-  {{- if and .Values.global.scmProviders.bitbucket.enabled .Values.global.scmProviders.webhookHost }}
-  BITBUCKET_WEBHOOK_URL: "http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{ .Values.global.scmProviders.webhookHost}}/webhook/bitbucket/"
+  {{- if and .Values.global.scmProviders.bitbucket.enabled $webhookHost }}
+  BITBUCKET_WEBHOOK_URL: "http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{ $webhookHost }}/webhook/bitbucket/"
   {{- end }}
 
   ENABLE_BLOBVAULT: "True"
@@ -67,8 +68,8 @@ data:
   {{- if .Values.global.scmProviders.github.url }}
   GITHUB_URL: {{ .Values.global.scmProviders.github.url | quote }}
   {{- end }}
-  {{- if and .Values.global.scmProviders.github.enabled .Values.global.scmProviders.webhookHost }}
-  GITHUB_WEBHOOK_URL: "http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{ .Values.global.scmProviders.webhookHost}}/webhook/github/"
+  {{- if and .Values.global.scmProviders.github.enabled $webhookHost }}
+  GITHUB_WEBHOOK_URL: "http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{ $webhookHost }}/webhook/github/"
   {{- end }}
   {{- if .Values.global.scmProviders.github.clientId }}
   GITHUB_APP_CLIENT_ID: {{ .Values.global.scmProviders.github.clientId | quote }}
@@ -83,8 +84,8 @@ data:
   {{- if .Values.global.scmProviders.gitlab.url }}
   GITLAB_URL: {{ .Values.global.scmProviders.gitlab.url | quote}}
   {{- end }}
-  {{- if and .Values.global.scmProviders.gitlab.enabled .Values.global.scmProviders.webhookHost }}
-  GITLAB_WEBHOOK_URL: "http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{ .Values.global.scmProviders.webhookHost}}/webhook/gitlab/"
+  {{- if and .Values.global.scmProviders.gitlab.enabled $webhookHost }}
+  GITLAB_WEBHOOK_URL: "http{{ if $.Values.global.ingress.tlsEnabled }}s{{ end }}://{{ $webhookHost }}/webhook/gitlab/"
   {{- end }}
 
   {{- if .Values.global.maxViews }}

--- a/charts/studio/templates/ingress-studio-webhook.yaml
+++ b/charts/studio/templates/ingress-studio-webhook.yaml
@@ -31,7 +31,7 @@ spec:
   {{- if and .Values.global.ingress.tlsEnabled .Values.global.ingress.hostnameEnabled }}
   tls:
     - hosts:
-        - {{ .Values.global.host }}
+        - {{.Values.global.scmProviders.webhookHost | default .Values.global.host}}
       secretName: {{ .Values.global.ingress.tlsSecretName }}
   {{- end }}
   rules:
@@ -56,6 +56,6 @@ spec:
               servicePort: {{ .Values.studioBackend.service.port }}
               {{- end }}
       {{- if .Values.global.ingress.hostnameEnabled }}
-      host: {{ .Values.global.host }}
+      host: {{ .Values.global.scmProviders.webhookHost | default .Values.global.host }}
       {{- end }}
 {{- end }}

--- a/charts/studio/templates/secret-studio.yaml
+++ b/charts/studio/templates/secret-studio.yaml
@@ -48,7 +48,7 @@ stringData:
   {{- else }}
   {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "studio") | default dict }}
   {{- $secretData := (get $secretObj "data") | default dict }}
-  {{- $secretKey := (get $secretData "SECRET_KEY" | b64dec) | default (randAscii 40) }}
+  {{- $secretKey := (get $secretData "SECRET_KEY" | b64dec) | default (randAlphaNum 40) }}
   SECRET_KEY: {{ $secretKey | quote }}
   {{- end }}
 

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -108,7 +108,7 @@ global:
     # @default -- `$global.host` value.
     webhookHost: ""
 
-    # -- Configure GitHub App integration with the Studio.
+    # -- GitHub App integration with Studio.
     github:
       # -- GitHub enabled
       enabled: false
@@ -132,7 +132,7 @@ global:
       # -- GitHub OAuth App Private Key
       privateKey: ""
 
-    # -- Configure GitLab App integration with the Studio.
+    # -- GitLab App integration with Studio.
     gitlab:
       # -- GitLab enabled
       enabled: false
@@ -149,7 +149,7 @@ global:
       # -- GitLab Webhook Secret
       webhookSecret: ""
 
-    # -- Configure BitBucket App integration with the Studio.
+    # -- BitBucket App integration with Studio.
     bitbucket:
       # -- Bitbucket enabled
       enabled: false

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -103,6 +103,12 @@ global:
     password: "postgres"
 
   scmProviders:
+
+    # -- Set custom hostname for incoming webhook  if you're using SaaS version of GitHub, GitLab or Bitbucket.
+    # @default -- `$global.host` value.
+    webhookHost: ""
+
+    # -- Configure GitHub App integration with the Studio.
     github:
       # -- GitHub enabled
       enabled: false
@@ -126,9 +132,7 @@ global:
       # -- GitHub OAuth App Private Key
       privateKey: ""
 
-      # -- GitHub Webhook URL, e.g. https://<global.host>/webhook/github/
-      webhookUrl: ""
-
+    # -- Configure GitLab App integration with the Studio.
     gitlab:
       # -- GitLab enabled
       enabled: false
@@ -142,11 +146,10 @@ global:
       # -- GitLab OAuth App Secret Key
       secretKey: ""
 
-      # -- GitLab Webhook URL
-      webhookUrl: ""
       # -- GitLab Webhook Secret
       webhookSecret: ""
 
+    # -- Configure BitBucket App integration with the Studio.
     bitbucket:
       # -- Bitbucket enabled
       enabled: false
@@ -162,9 +165,6 @@ global:
       clientId: ""
       # -- Bitbucket OAuth App Secret Key
       secretKey: ""
-
-      # -- Bitbucket Webhook URL
-      webhookUrl: ""
 
 nginx:
   service:

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -18,8 +18,8 @@ global:
   # We recommend you set this externally. If left empty, a random key will be generated.
   secretKey: ""
 
+  # -- (DEPRECATED) Studio: Custom CA certificate in PEM format
   # Deprecated in favor of `customCaCerts`
-  # -- Studio: Custom CA certificate in PEM format
   # customCaCert: |-
   #   -----BEGIN CERTIFICATE-----
   #   ....
@@ -120,7 +120,6 @@ global:
       # Set this if you're using the selfhosted version
       apiUrl: ""
 
-
       # -- GitHub OAuth App Name
       appName: ""
       # -- GitHub OAuth App ID
@@ -131,6 +130,9 @@ global:
       clientSecret: ""
       # -- GitHub OAuth App Private Key
       privateKey: ""
+
+      # -- (DEPRECATED) GitHub Webhook URL
+      webhookUrl: ""
 
     # -- GitLab App integration with Studio.
     gitlab:
@@ -145,6 +147,9 @@ global:
       clientId: ""
       # -- GitLab OAuth App Secret Key
       secretKey: ""
+
+      # -- (DEPRECATED) GitLab Webhook URL
+      webhookUrl: ""
 
       # -- GitLab Webhook Secret
       webhookSecret: ""
@@ -166,6 +171,8 @@ global:
       # -- Bitbucket OAuth App Secret Key
       secretKey: ""
 
+      # -- (DEPRECATED) BitBucket Webhook URL
+      webhookUrl: ""
 nginx:
   service:
     type: ClusterIP

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -104,7 +104,7 @@ global:
 
   scmProviders:
 
-    # -- Set custom hostname for incoming webhook  if you're using SaaS version of GitHub, GitLab or Bitbucket.
+    # -- Custom hostname for incoming webhook (if Studio runs on a private network and you use SaaS versions of GitHub, GitLab, or Bitbucket)
     # @default -- `$global.host` value.
     webhookHost: ""
 


### PR DESCRIPTION
This is alternative approach to https://github.com/iterative/helm-charts/pull/106.

It simplifies the configuration of the Webhooks, just to allow customize the hostname, if the user needs. @jesper7 explained that this value was to alow exposing the webhook endpoints under custom domains(e.g. public for SCM in SaaS), while studio would be in private network still.

Also, I generated the preview of [`helm-docs`](https://github.com/norwoodj/helm-docs) readme, just to preview the way of writing `@default` value :-) 

---
Marking this as a draft now, because there is missing support for removed values:
- `global.scmProviders.github.webhookUrl`
- `global.scmProviders.gitlab.webhookUrl`
- `global.scmProviders.bitbucket.webhookUrl`

IDKif it is not better to leave those parameters still, but mark them as deprecated for a while.



