### PR TITLE
Configure Postgres with separate env variables

### DIFF
--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.34
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.32
+version: 0.1.34
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.82.0"
+appVersion: "v1.88.4"
 
 maintainers:
   - name: iterative

--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.1.34
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.88.4"
+appVersion: "v2.4.0"
 
 maintainers:
   - name: iterative

--- a/charts/studio/templates/secret-studio.yaml
+++ b/charts/studio/templates/secret-studio.yaml
@@ -8,7 +8,17 @@ metadata:
     {{- include "studio.labels" . | nindent 4 }}
 type: Opaque
 stringData:
+  {{- if .Values.global.postgres.databaseUrl }}
+  # Deprecated configuration format.
+  # Will be removed in a future release
   DATABASE_URL: "psql://{{ .Values.global.postgres.databaseUser}}:{{ .Values.global.postgres.databasePassword }}@{{ .Values.global.postgres.databaseUrl }}"
+  {{- else }}
+  DATABASE_USER: {{ .Values.global.postgres.user | quote }}
+  DATABASE_PASSWORD: {{ .Values.global.postgres.password | quote }}
+  DATABASE_NAME: {{ .Values.global.postgres.databaseName | quote }}
+  DATABASE_HOST: {{ .Values.global.postgres.host | quote }}
+  DATABASE_PORT: {{ .Values.global.postgres.port | quote }}
+  {{- end }}
 
   {{- if .Values.global.scmProviders.gitlab.clientId }}
   GITLAB_CLIENT_ID: {{ .Values.global.scmProviders.gitlab.clientId | quote }}

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -68,12 +68,23 @@ global:
     tlsSecretName: chart-example-tls
 
   postgres:
-    # -- Postgres database URL
-    databaseUrl: "studio-postgresql:5432/iterativeai"
-    # -- Postgres database user
-    databaseUser: "postgres"
-    # -- Postgres database password
-    databasePassword: "postgres"
+    # -- (DEPRECATED) Postgres database URL
+    databaseUrl: ""
+    # -- (DEPRECATED) Postgres database user
+    databaseUser: ""
+    # -- (DEPRECATED) Postgres database password
+    databasePassword: ""
+
+    # -- Postgres hostname
+    host: "studio-postgresql"
+    # -- Postgres port
+    port: "5432"
+    # -- Postgres database name
+    databaseName: "iterativeai"
+    # -- Postgres user
+    user: "postgres"
+    # -- Postgres password
+    password: "postgres"
 
   scmProviders:
     github:


### PR DESCRIPTION
:warning: **This PR depends on a yet-to-be-released Studio version, so please hold on merging**

Some users may want to use Postgres variables with certain symbols such as `@` in them. Unfortunately, this breaks the Postgres connection URI, as certain symbols get treated as delimiters. 

To work around it, I've refactored the values and environment passed to Studio so that we always use separate environment variables for the Postgres configuration. This means that the previous fields:
- `global.postgres.databaseUrl`
- `global.postgres.databaseUser`
- `global.postgres.databasePassword`

are now deprecated.