### PR TITLE
Bump app version to v2.9.1

### DIFF
--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v2.4.0"
+appVersion: "v2.9.1"
 
 maintainers:
   - name: iterative


### PR DESCRIPTION
This PR bumps the Studio version to v2.9.1, which includes a fix for a critical regression that could prevent the backend container from launching.