### PR TITLE
feat(helm-chart): Add support for passing multiple custom certificate authorities

### DIFF
--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/studio/templates/configmap-ca-cert.yaml
+++ b/charts/studio/templates/configmap-ca-cert.yaml
@@ -7,3 +7,9 @@ data:
   self_signed_ca.crt: |
 {{ .Values.global.customCaCert | indent 4}}
   {{- end }}
+  {{- if .Values.global.customCaCerts }}
+    {{- range $index, $customCa := .Values.global.customCaCerts }}
+  self_signed_ca_{{ $index }}.crt:
+{{ $customCa | indent 4}}
+    {{- end }}
+  {{- end }}

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -18,6 +18,7 @@ global:
   # We recommend you set this externally. If left empty, a random key will be generated.
   secretKey: ""
 
+  # Deprecated in favor of `customCaCerts`
   # -- Studio: Custom CA certificate in PEM format
   # customCaCert: |-
   #   -----BEGIN CERTIFICATE-----
@@ -25,6 +26,16 @@ global:
   #   -----END CERTIFICATE-----
   #
   customCaCert: ""
+
+  # -- Studio: Custom CA certificate in PEM format
+  # customCaCerts:
+  # - |-
+  #     -----BEGIN CERTIFICATE-----
+  #     ....
+  #     -----END CERTIFICATE-----
+  #
+  customCaCerts: []
+
 
   # -- Studio: Additional environment variables for all pods
   envVars: {}


### PR DESCRIPTION
This PR add support setting multiple Custom CA Certificates by new value `customCaCertificates` with `list type` and deprecates previous one `customCaCertificate` with `string type`. 