### PR TITLE
Set default timeout of 20 seconds for Redis

### DIFF
--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -253,6 +253,9 @@ redis:
   # -- Redis name override
   fullnameOverride: studio-redis
 
+  commonConfiguration: |-
+    timeout 20
+
   auth:
     # -- Redis authentication enabled
     enabled: false


### PR DESCRIPTION
This PR sets a default timeout of 20 seconds for idle connections in Redis. Although Studio does limit the connections made to Redis, idle connections may occur if a container crashes. So, to be on the safe side, let's enforce this in Redis.