### PR TITLE
fix(redis): Remove fullnameOverride from redis

### DIFF
--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.7
+version: 0.2.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/studio/templates/configmap-studio.yaml
+++ b/charts/studio/templates/configmap-studio.yaml
@@ -46,19 +46,19 @@ data:
   {{- if .Values.global.celery.brokerUrl }}
   CELERY_BROKER_URL: {{ .Values.global.celery.brokerUrl }}
   {{- else }}
-  CELERY_BROKER_URL: "redis://{{ .Values.redis.fullnameOverride }}-master.{{ .Release.Namespace }}.svc.cluster.local:6379"
+  CELERY_BROKER_URL: "redis://{{ .Release.Name }}-redis-master.{{ .Release.Namespace }}.svc.cluster.local:6379"
   {{- end }}
 
   {{- if .Values.global.celery.resultBackend }}
   CELERY_RESULT_BACKEND: {{ .Values.global.celery.resultBackend }}
   {{- else }}
-  CELERY_RESULT_BACKEND: "redis://{{ .Values.redis.fullnameOverride }}-master.{{ .Release.Namespace }}.svc.cluster.local:6379"
+  CELERY_RESULT_BACKEND: "redis://{{ .Release.Name }}-redis-master.{{ .Release.Namespace }}.svc.cluster.local:6379"
   {{- end }}
 
   {{- if .Values.global.celery.resultBackend }}
   REDIS_URL: {{ .Values.global.celery.resultBackend }}
   {{- else }}
-  REDIS_URL: "redis://{{ .Values.redis.fullnameOverride }}-master.{{ .Release.Namespace }}.svc.cluster.local:6379"
+  REDIS_URL: "redis://{{ .Release.Name }}-redis-master.{{ .Release.Namespace }}.svc.cluster.local:6379"
   {{- end }}
 
   {{- if .Values.global.scmProviders.github.apiUrl }}

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -255,8 +255,13 @@ nginx:
 redis:
   # -- Redis enabled
   enabled: true
-  # -- Redis name override
-  fullnameOverride: studio-redis
+
+  # -- Redis master configuration
+  master:
+    # -- Redis master persistence configuration
+    persistence:
+      # -- Redis master persistence size in PVC
+      size: "1Gi"
 
   # -- Redis master configuration
   master:

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -258,13 +258,6 @@ redis:
 
   # -- Redis master configuration
   master:
-    # -- Redis master persistence configuration
-    persistence:
-      # -- Redis master persistence size in PVC
-      size: "1Gi"
-
-  # -- Redis master configuration
-  master:
     ## Redis&reg; master resource requests and limits
     ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
     ## @param master.resources.limits The resources limits for the Redis&reg; master containers


### PR DESCRIPTION
Waits for https://github.com/iterative/helm-charts/pull/21

Copying @omesser comment from #123 

> I recommend the approach where for such things we provide a full name override but the default behavior is to calculate the name in the chart, so the fullnameOverride value is either commented out (@jesper7 will hate it) or just empty string.
> 
> We can create a helper template (in _helpers.tpl) along those lines:
> 
> ```go
> {{- define "studio.rayOperator.fullname" -}}
> {{- if .Values.rayOperator.fullnameOverride -}}
> {{- .Values.rayOperator.fullnameOverride | trunc 63 | trimSuffix "-" -}}
> {{- else -}}
> {{- printf "%s-ray-operator" .Release.Name | trunc 63 | trimSuffix "-" -}}
> {{- end -}}
> {{- end -}}
> ```
> and use in values via `{{ include "studio.rayOperator.fullname" . }}`
> 
> Whenever we have such if-else boilerplate to calc a name or field - we can move it to a helper value to keep the resource charts clean and we would probably end up reusing a lot of those.
> 
> don't have a strong opinion about ray vs rayOperator but since the actual ray cluster is a CRD and not the operator that's installed in the chart it might be less confusing to make the distinction obvious via naming, harming brevity