### PR TITLE
feat(secrets): Allow passing secret environments outside Helm

### DIFF
--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.8
+version: 0.2.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/studio/templates/deployment-studio-backend.yaml
+++ b/charts/studio/templates/deployment-studio-backend.yaml
@@ -52,6 +52,14 @@ spec:
                 name: studio-backend
             - secretRef:
                 name: studio
+            {{- if .Values.global.envFromSecret }}
+            - secretRef:
+                name: {{ .Values.global.envFromSecret }}
+            {{- end }}
+            {{- if .Values.studioBackend.envFromSecret }}
+            - secretRef:
+                name: {{ .Values.studioBackend.envFromSecret }}
+            {{- end }}
       containers:
         - name: studio-backend
           securityContext:
@@ -106,6 +114,14 @@ spec:
                 name: studio-backend
             - secretRef:
                 name: studio
+            {{- if .Values.global.envFromSecret }}
+            - secretRef:
+                name: {{ .Values.global.envFromSecret }}
+            {{- end }}
+            {{- if .Values.studioBackend.envFromSecret }}
+            - secretRef:
+                name: {{ .Values.studioBackend.envFromSecret }}
+            {{- end }}
       {{- if .Values.global.customCaCert }}
       volumes:
         - name: studio-ca-certificates

--- a/charts/studio/templates/deployment-studio-beat.yaml
+++ b/charts/studio/templates/deployment-studio-beat.yaml
@@ -53,6 +53,14 @@ spec:
                 name: studio-beat
             - secretRef:
                 name: studio
+            {{- if .Values.global.envFromSecret }}
+            - secretRef:
+                name: {{ .Values.global.envFromSecret }}
+            {{- end }}
+            {{- if .Values.studioBeat.envFromSecret }}
+            - secretRef:
+                name: {{ .Values.studioBeat.envFromSecret }}
+            {{- end }}
           {{- if .Values.global.customCaCert }}
           volumeMounts:
             - name: studio-ca-certificates

--- a/charts/studio/templates/deployment-studio-ui.yaml
+++ b/charts/studio/templates/deployment-studio-ui.yaml
@@ -65,6 +65,14 @@ spec:
                 name: studio-ui
             - secretRef:
                 name: studio
+            {{- if .Values.global.envFromSecret }}
+            - secretRef:
+                name: {{ .Values.global.envFromSecret }}
+            {{- end }}
+            {{- if .Values.studioUi.envFromSecret }}
+            - secretRef:
+                name: {{ .Values.studioUi.envFromSecret }}
+            {{- end }}
           {{- if .Values.global.customCaCert }}
           volumeMounts:
             - name: studio-ca-certificates

--- a/charts/studio/templates/deployment-studio-worker.yaml
+++ b/charts/studio/templates/deployment-studio-worker.yaml
@@ -53,6 +53,14 @@ spec:
                 name: studio-worker
             - secretRef:
                 name: studio
+            {{- if .Values.global.envFromSecret }}
+            - secretRef:
+                name: {{ .Values.global.envFromSecret }}
+            {{- end }}
+            {{- if .Values.studioWorker.envFromSecret }}
+            - secretRef:
+                name: {{ .Values.studioWorker.envFromSecret }}
+            {{- end }}
           volumeMounts:
             - name: blobvault
               mountPath: /blobvault

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -43,8 +43,8 @@ global:
   # envVars:
   #   DEBUG: "True"
 
-  # -- Studio: The name of a secret in the same kubernetes namespace which contain values to be added
-  # to all Studio pods as environment variables.
+  # -- Studio: The name of an existing Secret that contains sensitive environment variables
+  # passed to all Studio pods.
   envFromSecret: ""
 
   blobvault:
@@ -327,8 +327,8 @@ studioUi:
   # envVars:
   #   DEBUG: "True"
 
-  # -- The name of a secret in the same kubernetes namespace which contain values to be added
-  # UI pods as environment variables.
+  # -- Studio: The name of an existing Secret that contains sensitive environment variables
+  # passed to UI pods.
   envFromSecret: ""
 
   replicaCount: 1
@@ -388,8 +388,8 @@ studioBackend:
   # envVars:
   #   DEBUG: "True"
 
-  # -- The name of a secret in the same kubernetes namespace which contain values to be added
-  # Backend pods as environment variables.
+  # -- Studio: The name of an existing Secret that contains sensitive environment variables
+  # passed to backend pods.
   envFromSecret: ""
 
   replicaCount: 1
@@ -449,8 +449,8 @@ studioBeat:
   # envVars:
   #   DEBUG: "True"
 
-  # -- The name of a secret in the same kubernetes namespace which contain values to be added
-  # Beat pods as environment variables.
+  # -- Studio: The name of an existing Secret that contains sensitive environment variables
+  # passed to beat pods.
   envFromSecret: ""
 
   replicaCount: 1
@@ -500,8 +500,8 @@ studioWorker:
   # envVars:
   #   DEBUG: "True"
 
-  # -- The name of a secret in the same kubernetes namespace which contain values to be added
-  # Worker pods as environment variables.
+  # -- Studio: The name of an existing Secret that contains sensitive environment variables
+  # passed to worker pods.
   envFromSecret: ""
 
   replicaCount: 1

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -43,6 +43,10 @@ global:
   # envVars:
   #   DEBUG: "True"
 
+  # -- Studio: The name of a secret in the same kubernetes namespace which contain values to be added
+  # to all Studio pods as environment variables.
+  envFromSecret: ""
+
   blobvault:
     # -- Blobvault local backing store size
     persistentVolume:
@@ -79,7 +83,7 @@ global:
     className: ""
     annotations: {}
       # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
+      # kubernetes.io/tls-acme: "true"
     tlsEnabled: false
     tlsSecretName: chart-example-tls
 
@@ -323,6 +327,10 @@ studioUi:
   # envVars:
   #   DEBUG: "True"
 
+  # -- The name of a secret in the same kubernetes namespace which contain values to be added
+  # UI pods as environment variables.
+  envFromSecret: ""
+
   replicaCount: 1
 
   image:
@@ -379,6 +387,10 @@ studioBackend:
   # Example:
   # envVars:
   #   DEBUG: "True"
+
+  # -- The name of a secret in the same kubernetes namespace which contain values to be added
+  # Backend pods as environment variables.
+  envFromSecret: ""
 
   replicaCount: 1
 
@@ -437,6 +449,10 @@ studioBeat:
   # envVars:
   #   DEBUG: "True"
 
+  # -- The name of a secret in the same kubernetes namespace which contain values to be added
+  # Beat pods as environment variables.
+  envFromSecret: ""
+
   replicaCount: 1
 
   resources:
@@ -483,6 +499,10 @@ studioWorker:
   # Example:
   # envVars:
   #   DEBUG: "True"
+
+  # -- The name of a secret in the same kubernetes namespace which contain values to be added
+  # Worker pods as environment variables.
+  envFromSecret: ""
 
   replicaCount: 1
 


### PR DESCRIPTION
Before, all secret environments were defined in `values.yaml`. There was no way to set secret managed in the external vault engine(AWS Secret Manager, Hashicorp Vault). This PR allow us to load parameters from them.