### PR TITLE
fix(customCa): Always mount CA certificate volume

### DIFF
--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.12
+version: 0.2.13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/studio/README.md
+++ b/charts/studio/README.md
@@ -1,6 +1,6 @@
 # studio
 
-![Version: 0.2.12](https://img.shields.io/badge/Version-0.2.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.9.1](https://img.shields.io/badge/AppVersion-v2.9.1-informational?style=flat-square)
+![Version: 0.2.13](https://img.shields.io/badge/Version-0.2.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.9.1](https://img.shields.io/badge/AppVersion-v2.9.1-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/charts/studio/templates/deployment-studio-backend.yaml
+++ b/charts/studio/templates/deployment-studio-backend.yaml
@@ -96,11 +96,9 @@ spec:
             periodSeconds: 10
             failureThreshold: 5
             timeoutSeconds: 60
-          {{- if .Values.global.customCaCert }}
           volumeMounts:
             - name: studio-ca-certificates
               mountPath: /usr/local/share/ca-certificates
-          {{- end }}
           resources:
             {{- toYaml .Values.studioBackend.resources | nindent 12 }}
           env:
@@ -123,12 +121,10 @@ spec:
             - secretRef:
                 name: {{ .Values.studioBackend.envFromSecret }}
             {{- end }}
-      {{- if .Values.global.customCaCert }}
       volumes:
         - name: studio-ca-certificates
           configMap:
             name: studio-ca-certificates
-      {{- end }}
       {{- with .Values.studioBackend.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/studio/templates/deployment-studio-beat.yaml
+++ b/charts/studio/templates/deployment-studio-beat.yaml
@@ -62,17 +62,13 @@ spec:
             - secretRef:
                 name: {{ .Values.studioBeat.envFromSecret }}
             {{- end }}
-          {{- if .Values.global.customCaCert }}
           volumeMounts:
             - name: studio-ca-certificates
               mountPath: /usr/local/share/ca-certificates
-          {{- end }}
-      {{- if .Values.global.customCaCert }}
       volumes:
         - name: studio-ca-certificates
           configMap:
             name: studio-ca-certificates
-      {{- end }}
       {{- with .Values.studioBeat.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/studio/templates/deployment-studio-ui.yaml
+++ b/charts/studio/templates/deployment-studio-ui.yaml
@@ -74,19 +74,15 @@ spec:
             - secretRef:
                 name: {{ .Values.studioUi.envFromSecret }}
             {{- end }}
-          {{- if .Values.global.customCaCert }}
           volumeMounts:
             - name: studio-ca-certificates
               mountPath: /usr/local/share/ca-certificates
-          {{- end }}
           resources:
             {{- toYaml .Values.studioUi.resources | nindent 12 }}
-      {{- if .Values.global.customCaCert }}
       volumes:
         - name: studio-ca-certificates
           configMap:
             name: studio-ca-certificates
-      {{- end }}
       {{- with .Values.studioUi.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/studio/templates/deployment-studio-worker.yaml
+++ b/charts/studio/templates/deployment-studio-worker.yaml
@@ -65,19 +65,15 @@ spec:
           volumeMounts:
             - name: blobvault
               mountPath: /blobvault
-            {{- if .Values.global.customCaCert }}
             - name: studio-ca-certificates
               mountPath: /usr/local/share/ca-certificates
-            {{- end }}
       volumes:
         - name: blobvault
           persistentVolumeClaim:
             claimName: blobvault
-        {{- if .Values.global.customCaCert }}
         - name: studio-ca-certificates
           configMap:
             name: studio-ca-certificates
-        {{- end }}
       {{- with .Values.studioWorker.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
In https://github.com/iterative/helm-charts/pull/110, we added support for defining multiple certificate authorities. Unfortunately, this change involved a rename, breaking the volume mount on the existing deployment templates. 

To prevent this from happening again, let's always mount the CA certificate volume. It doesn't matter if it is empty.