### PR TITLE
feat(dvcx-worker): Add DVCx Worker definition

### DIFF
--- a/.github/workflows/helm-lint-and-install.yaml
+++ b/.github/workflows/helm-lint-and-install.yaml
@@ -1,4 +1,4 @@
-name: Lint and Test Charts
+helm-lint-and-test: Lint and Test Charts
 
 on:
   pull_request:
@@ -57,7 +57,7 @@ jobs:
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'
         run: |
-          ct lint-and-install --target-branch ${{ github.event.repository.default_branch }} --upgrade --debug \
+          ct lint-and-install --target-branch ${{ github.event.repository.default_branch }} --upgrade --skip-missing-values --debug \
           --helm-extra-set-args '--set ci=true --set global.blobvault.persistentVolume.storageClassName="standard" --set imagePullSecrets[0].name=iterativeai --set dockerUsername=${{ secrets.ITERATIVE_DOCKER_REGISTRY_USER }} --set dockerPassword=${{ secrets.ITERATIVE_DOCKER_REGISTRY_PASSWORD }} --set dockerServer=docker.iterative.ai'
 
   helm-docs:

--- a/.github/workflows/helm-lint-and-install.yaml
+++ b/.github/workflows/helm-lint-and-install.yaml
@@ -1,4 +1,4 @@
-helm-lint-and-test: Lint and Test Charts
+name: Lint and Test Charts
 
 on:
   pull_request:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 *.tgz
 override.yaml
 .idea
-/charts/studio/local-values.yaml
+/charts/studio/values-local-dev.yaml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,8 +40,8 @@ When it is ready, open the browser and go to http://localhost. You should see th
 
 ### Skaffold profile - `local`
 
-If you want to run skaffold with `local` profile, you need to create `local-values.yaml` file in
-`charts/studio/local-values.yaml`. The values should contain the overrides for the values of the
+If you want to run skaffold with `local` profile, you need to create `values-local-dev.yaml` file in
+`charts/studio/values-local-dev.yaml`. The values should contain the overrides for the values of the
 chart. 
 
 To use the profile, run skaffold with following command:

--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -1,23 +1,8 @@
 apiVersion: v2
 name: studio
 description: A Helm chart for Kubernetes
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.20
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-# It is recommended to use it with quotes.
+version: 0.3.0
 appVersion: "v2.21.0"
 maintainers:
   - name: iterative

--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.19
+version: 0.2.20
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/studio/README.md
+++ b/charts/studio/README.md
@@ -1,6 +1,6 @@
 # studio
 
-![Version: 0.2.19](https://img.shields.io/badge/Version-0.2.19-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.21.0](https://img.shields.io/badge/AppVersion-v2.21.0-informational?style=flat-square)
+![Version: 0.2.20](https://img.shields.io/badge/Version-0.2.20-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.21.0](https://img.shields.io/badge/AppVersion-v2.21.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -88,7 +88,7 @@ A Helm chart for Kubernetes
 | nginx.extraVolumes[0].name | string | `"blobvault"` |  |
 | nginx.extraVolumes[0].persistentVolumeClaim.claimName | string | `"blobvault"` |  |
 | nginx.ingress.enabled | bool | `false` |  |
-| nginx.serverBlock | string | `"server {\n    listen       8080;\n    server_name  _;\n\n    root /blobvault;\n\n    location ~ \\.gz$ {\n        if ($request_method = 'OPTIONS') {\n            add_header 'Access-Control-Allow-Origin' '*';\n            #\n            # Cookies\n            #\n            add_header 'Access-Control-Allow-Credentials' 'true';\n            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';\n            #\n            # Custom headers and headers various browsers *should* be OK with but aren't\n            #\n            add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,X-Studio-Trace-Id';\n            #\n            # Tell client that this pre-flight info is valid for 20 days\n            #\n            add_header 'Access-Control-Max-Age' 1728000;\n            add_header 'Content-Type' 'text/plain charset=UTF-8';\n            add_header 'Content-Length' 0;\n            return 204;\n        }\n        if ($request_method = 'GET') {\n            add_header 'Access-Control-Allow-Origin' '*';\n            add_header 'Access-Control-Allow-Credentials' 'true';\n            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';\n            add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,X-Studio-Trace-Id';\n            add_header Content-Encoding gzip;\n        }\n        gzip off;\n        types { } default_type \"application/json\";\n    }\n\n\n    location / {\n        if ($request_method = 'OPTIONS') {\n            add_header 'Access-Control-Allow-Origin' '*';\n            #\n            # Cookies\n            #\n            add_header 'Access-Control-Allow-Credentials' 'true';\n            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';\n            #\n            # Custom headers and headers various browsers *should* be OK with but aren't\n            #\n            add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,X-Studio-Trace-Id';\n            #\n            # Tell client that this pre-flight info is valid for 20 days\n            #\n            add_header 'Access-Control-Max-Age' 1728000;\n            add_header 'Content-Type' 'text/plain charset=UTF-8';\n            add_header 'Content-Length' 0;\n            return 204;\n        }\n        if ($request_method = 'GET') {\n            add_header 'Access-Control-Allow-Origin' '*';\n            add_header 'Access-Control-Allow-Credentials' 'true';\n            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';\n            add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,X-Studio-Trace-Id';\n        }\n\n        try_files $uri $uri/ =404;\n    }\n}"` |  |
+| nginx.serverBlock | string | see in `values.yaml` | Nginx for blobvault configuration |
 | nginx.service.type | string | `"ClusterIP"` |  |
 | postgresql.enabled | bool | `true` | Postgres enabled |
 | postgresql.fullnameOverride | string | `"studio-postgresql"` | Postgres name override |
@@ -109,90 +109,56 @@ A Helm chart for Kubernetes
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `false` |  |
 | serviceAccount.name | string | `""` |  |
-| studioBackend.affinity | object | `{}` |  |
-| studioBackend.autoscaling.enabled | bool | `false` |  |
-| studioBackend.autoscaling.maxReplicas | int | `5` |  |
-| studioBackend.autoscaling.minReplicas | int | `1` |  |
-| studioBackend.autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
-| studioBackend.envFromSecret | string | `""` | Studio: The name of an existing Secret that contains sensitive environment variables passed to backend pods. |
-| studioBackend.envVars | object | `{}` | Studio: Additional environment variables for backend pods |
-| studioBackend.fullnameOverride | string | `""` |  |
-| studioBackend.image.pullPolicy | string | `"IfNotPresent"` |  |
-| studioBackend.image.repository | string | `"docker.iterative.ai/studio-backend"` |  |
-| studioBackend.nameOverride | string | `""` |  |
-| studioBackend.nodeSelector | object | `{}` |  |
-| studioBackend.podAnnotations | object | `{}` |  |
-| studioBackend.podSecurityContext | object | `{}` |  |
-| studioBackend.replicaCount | int | `1` |  |
-| studioBackend.resources.limits.cpu | string | `"1000m"` |  |
-| studioBackend.resources.limits.memory | string | `"2Gi"` |  |
-| studioBackend.resources.requests.cpu | string | `"500m"` |  |
-| studioBackend.resources.requests.memory | string | `"1Gi"` |  |
-| studioBackend.securityContext | object | `{}` |  |
-| studioBackend.service.port | int | `8000` |  |
-| studioBackend.service.type | string | `"ClusterIP"` |  |
-| studioBackend.tolerations | list | `[]` |  |
-| studioBeat.affinity | object | `{}` |  |
-| studioBeat.autoscaling.enabled | bool | `false` |  |
-| studioBeat.autoscaling.maxReplicas | int | `5` |  |
-| studioBeat.autoscaling.minReplicas | int | `1` |  |
-| studioBeat.autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
-| studioBeat.envFromSecret | string | `""` | Studio: The name of an existing Secret that contains sensitive environment variables passed to beat pods. |
-| studioBeat.envVars | object | `{}` | Studio: Additional environment variables for beat pods |
-| studioBeat.fullnameOverride | string | `""` |  |
-| studioBeat.nameOverride | string | `""` |  |
-| studioBeat.nodeSelector | object | `{}` |  |
-| studioBeat.podAnnotations | object | `{}` |  |
-| studioBeat.podSecurityContext | object | `{}` |  |
-| studioBeat.replicaCount | int | `1` |  |
-| studioBeat.resources.limits.cpu | string | `"200m"` |  |
-| studioBeat.resources.limits.memory | string | `"256Mi"` |  |
-| studioBeat.resources.requests.cpu | string | `"100m"` |  |
-| studioBeat.resources.requests.memory | string | `"128Mi"` |  |
-| studioBeat.securityContext | object | `{}` |  |
-| studioBeat.tolerations | list | `[]` |  |
-| studioUi.affinity | object | `{}` |  |
-| studioUi.autoscaling.enabled | bool | `false` |  |
-| studioUi.autoscaling.maxReplicas | int | `5` |  |
-| studioUi.autoscaling.minReplicas | int | `1` |  |
-| studioUi.autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
-| studioUi.envFromSecret | string | `""` | Studio: The name of an existing Secret that contains sensitive environment variables passed to UI pods. |
-| studioUi.envVars | object | `{}` | Studio: Additional environment variables for ui pods |
-| studioUi.fullnameOverride | string | `""` |  |
-| studioUi.image.pullPolicy | string | `"IfNotPresent"` |  |
-| studioUi.image.repository | string | `"docker.iterative.ai/studio-frontend"` |  |
-| studioUi.nameOverride | string | `""` |  |
-| studioUi.nodeSelector | object | `{}` |  |
-| studioUi.podAnnotations | object | `{}` |  |
-| studioUi.podSecurityContext | object | `{}` |  |
-| studioUi.replicaCount | int | `1` |  |
-| studioUi.resources.limits.cpu | string | `"1000m"` |  |
-| studioUi.resources.limits.memory | string | `"2Gi"` |  |
-| studioUi.resources.requests.cpu | string | `"500m"` |  |
-| studioUi.resources.requests.memory | string | `"1Gi"` |  |
-| studioUi.securityContext | object | `{}` |  |
-| studioUi.service.port | int | `3000` |  |
-| studioUi.service.type | string | `"ClusterIP"` |  |
-| studioUi.tolerations | list | `[]` |  |
-| studioWorker.affinity | object | `{}` |  |
-| studioWorker.autoscaling.enabled | bool | `false` |  |
-| studioWorker.autoscaling.maxReplicas | int | `5` |  |
-| studioWorker.autoscaling.minReplicas | int | `1` |  |
-| studioWorker.autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
-| studioWorker.envFromSecret | string | `""` | Studio: The name of an existing Secret that contains sensitive environment variables passed to worker pods. |
-| studioWorker.envVars | object | `{}` | Studio: Additional environment variables for worker pods |
-| studioWorker.fullnameOverride | string | `""` |  |
-| studioWorker.nameOverride | string | `""` |  |
-| studioWorker.nodeSelector | object | `{}` |  |
-| studioWorker.podAnnotations | object | `{}` |  |
-| studioWorker.podSecurityContext | object | `{}` |  |
-| studioWorker.replicaCount | int | `1` |  |
-| studioWorker.resources.limits.cpu | string | `"1000m"` |  |
-| studioWorker.resources.limits.memory | string | `"1Gi"` |  |
-| studioWorker.resources.requests.cpu | string | `"500m"` |  |
-| studioWorker.resources.requests.memory | string | `"512Mi"` |  |
-| studioWorker.securityContext | object | `{}` |  |
-| studioWorker.tolerations | list | `[]` |  |
+| studioBackend | object | `{"affinity":{},"autoscaling":{"enabled":false,"maxReplicas":5,"minReplicas":1,"targetCPUUtilizationPercentage":80},"envFromSecret":"","envVars":{},"fullnameOverride":"","image":{"pullPolicy":"IfNotPresent","repository":"docker.iterative.ai/studio-backend"},"nameOverride":"","nodeSelector":{},"podAnnotations":{},"podSecurityContext":{},"replicaCount":1,"resources":{"limits":{"cpu":"1000m","memory":"2Gi"},"requests":{"cpu":"500m","memory":"1Gi"}},"securityContext":{},"service":{"port":8000,"type":"ClusterIP"},"tolerations":[]}` | Studio Backend settings group |
+| studioBackend.envFromSecret | string | `""` | The name of an existing Secret that contains sensitive environment variables passed to backend pods. |
+| studioBackend.envVars | object | `{}` | Additional environment variables for backend pods |
+| studioBackend.replicaCount | int | `1` | Number of replicas of backend pods |
+| studioBeat | object | `{"affinity":{},"autoscaling":{"enabled":false,"maxReplicas":5,"minReplicas":1,"targetCPUUtilizationPercentage":80},"envFromSecret":"","envVars":{},"fullnameOverride":"","nameOverride":"","nodeSelector":{},"podAnnotations":{},"podSecurityContext":{},"replicaCount":1,"resources":{"limits":{"cpu":"200m","memory":"256Mi"},"requests":{"cpu":"100m","memory":"128Mi"}},"securityContext":{},"tolerations":[]}` | Studio Beat settings group |
+| studioBeat.envFromSecret | string | `""` | The name of an existing Secret that contains sensitive environment variables passed to beat pods. |
+| studioBeat.envVars | object | `{}` | Additional environment variables for beat pods |
+| studioDvcxWorker | object | `{"affinity":{},"autoscaling":{"enabled":false,"maxReplicas":5,"minReplicas":1,"targetCPUUtilizationPercentage":80},"envFromSecret":"","envVars":{},"ephemeralStorage":{"persistentVolumeClaim":{"storageClass":""},"sizeLimit":"1Gi","type":"emptyDir"},"image":{"pullPolicy":"IfNotPresent","repository":"docker.iterative.ai/studio-backend"},"nodeSelector":{},"podAnnotations":{},"podSecurityContext":{},"replicaCount":1,"resources":{"limits":{"cpu":"8000m","ephemeral-storage":"10Gi","memory":"16Gi"},"requests":{"cpu":"500m","ephemeral-storage":"500Mi","memory":"512Mi"}},"securityContext":{},"tolerations":[]}` | Studio DVCx Worker settings group |
+| studioDvcxWorker.affinity | object | `{}` | DVCx worker pod affinity configuration |
+| studioDvcxWorker.autoscaling | object | `{"enabled":false,"maxReplicas":5,"minReplicas":1,"targetCPUUtilizationPercentage":80}` | DVCx worker autoscaling configuration |
+| studioDvcxWorker.autoscaling.enabled | bool | `false` | DVCx worker autoscaling enabled flag |
+| studioDvcxWorker.autoscaling.maxReplicas | int | `5` | DVCx worker autoscaling max replicas |
+| studioDvcxWorker.autoscaling.minReplicas | int | `1` | DVCx worker autoscaling min replicas |
+| studioDvcxWorker.autoscaling.targetCPUUtilizationPercentage | int | `80` | DVCx worker autoscaling target CPU utilization percentage |
+| studioDvcxWorker.envFromSecret | string | `""` | The name of an existing Secret that contains sensitive environment variables passed to DVCx worker pods. |
+| studioDvcxWorker.envVars | object | `{}` | Additional environment variables for DVCx worker pods |
+| studioDvcxWorker.ephemeralStorage | object | `{"persistentVolumeClaim":{"storageClass":""},"sizeLimit":"1Gi","type":"emptyDir"}` | Ephemeral storage configuration |
+| studioDvcxWorker.ephemeralStorage.persistentVolumeClaim | object | `{"storageClass":""}` | Persistent Volume Claim configuration for ephemeral storage |
+| studioDvcxWorker.ephemeralStorage.persistentVolumeClaim.storageClass | string | `""` | Persistent Volume Claim `storageClass` name, by default it will use the default `storageClass` |
+| studioDvcxWorker.ephemeralStorage.type | string | `"emptyDir"` | Ephemeral Storage type. Possible values: `emptyDir`, `pvc` |
+| studioDvcxWorker.image | object | `{"pullPolicy":"IfNotPresent","repository":"docker.iterative.ai/studio-backend"}` | DVCx worker image settings |
+| studioDvcxWorker.image.repository | string | `"docker.iterative.ai/studio-backend"` | DVCx worker image repository |
+| studioDvcxWorker.nodeSelector | object | `{}` | DVCx worker pod node selector configuration |
+| studioDvcxWorker.podAnnotations | object | `{}` | Additional DVCx worker pod annotations |
+| studioDvcxWorker.podSecurityContext | object | `{}` | DVCx worker pod security context configuration |
+| studioDvcxWorker.resources | object | `{"limits":{"cpu":"8000m","ephemeral-storage":"10Gi","memory":"16Gi"},"requests":{"cpu":"500m","ephemeral-storage":"500Mi","memory":"512Mi"}}` | DVCx worker resources configuration |
+| studioDvcxWorker.resources.limits | object | `{"cpu":"8000m","ephemeral-storage":"10Gi","memory":"16Gi"}` | DVCx worker limits configuration |
+| studioDvcxWorker.resources.requests | object | `{"cpu":"500m","ephemeral-storage":"500Mi","memory":"512Mi"}` | DVCx worker requests configuration |
+| studioDvcxWorker.securityContext | object | `{}` | DVCx worker pod security context configuration |
+| studioDvcxWorker.tolerations | list | `[]` | DVCx worker pod tolerations configuration |
+| studioUi | object | `{"affinity":{},"autoscaling":{"enabled":false,"maxReplicas":5,"minReplicas":1,"targetCPUUtilizationPercentage":80},"envFromSecret":"","envVars":{},"fullnameOverride":"","image":{"pullPolicy":"IfNotPresent","repository":"docker.iterative.ai/studio-frontend"},"nameOverride":"","nodeSelector":{},"podAnnotations":{},"podSecurityContext":{},"replicaCount":1,"resources":{"limits":{"cpu":"1000m","memory":"2Gi"},"requests":{"cpu":"500m","memory":"1Gi"}},"securityContext":{},"service":{"port":3000,"type":"ClusterIP"},"tolerations":[]}` | Studio UI settings group |
+| studioUi.envFromSecret | string | `""` | The name of an existing Secret that contains sensitive environment variables passed to UI pods. |
+| studioUi.envVars | object | `{}` | Additional environment variables for ui pods |
+| studioWorker | object | `{"affinity":{},"autoscaling":{"enabled":false,"maxReplicas":5,"minReplicas":1,"targetCPUUtilizationPercentage":80},"envFromSecret":"","envVars":{},"nodeSelector":{},"podAnnotations":{},"podSecurityContext":{},"replicaCount":1,"resources":{"limits":{"cpu":"1000m","memory":"1Gi"},"requests":{"cpu":"500m","memory":"512Mi"}},"securityContext":{},"tolerations":[]}` | Studio Worker settings group |
+| studioWorker.affinity | object | `{}` | Worker affinity |
+| studioWorker.autoscaling | object | `{"enabled":false,"maxReplicas":5,"minReplicas":1,"targetCPUUtilizationPercentage":80}` | Worker autoscaling configuration |
+| studioWorker.autoscaling.enabled | bool | `false` | Worker autoscaling enabled flag |
+| studioWorker.autoscaling.maxReplicas | int | `5` | Worker autoscaling maximum replicas |
+| studioWorker.autoscaling.minReplicas | int | `1` | Worker autoscaling minimum replicas |
+| studioWorker.autoscaling.targetCPUUtilizationPercentage | int | `80` | Worker autoscaling target CPU utilization percentage |
+| studioWorker.envFromSecret | string | `""` | The name of an existing Secret that contains sensitive environment variables passed to worker pods. |
+| studioWorker.envVars | object | `{}` | Additional environment variables for worker pods |
+| studioWorker.nodeSelector | object | `{}` | Worker node selector |
+| studioWorker.podAnnotations | object | `{}` | Additional worker pod annotations |
+| studioWorker.podSecurityContext | object | `{}` | Worker pod security context |
+| studioWorker.resources | object | `{"limits":{"cpu":"1000m","memory":"1Gi"},"requests":{"cpu":"500m","memory":"512Mi"}}` | Worker resources configuration |
+| studioWorker.resources.limits | object | `{"cpu":"1000m","memory":"1Gi"}` | Worker resource limits configuration |
+| studioWorker.resources.requests | object | `{"cpu":"500m","memory":"512Mi"}` | Worker resource requests configuration |
+| studioWorker.securityContext | object | `{}` | Worker security context |
+| studioWorker.tolerations | list | `[]` | Worker tolerations |
 
 ----------------------------------------------
 Autogenerated from chart metadata using [helm-docs v1.11.0](https://github.com/norwoodj/helm-docs/releases/v1.11.0)

--- a/charts/studio/README.md
+++ b/charts/studio/README.md
@@ -116,7 +116,7 @@ A Helm chart for Kubernetes
 | studioBeat | object | `{"affinity":{},"autoscaling":{"enabled":false,"maxReplicas":5,"minReplicas":1,"targetCPUUtilizationPercentage":80},"envFromSecret":"","envVars":{},"fullnameOverride":"","nameOverride":"","nodeSelector":{},"podAnnotations":{},"podSecurityContext":{},"replicaCount":1,"resources":{"limits":{"cpu":"200m","memory":"256Mi"},"requests":{"cpu":"100m","memory":"128Mi"}},"securityContext":{},"tolerations":[]}` | Studio Beat settings group |
 | studioBeat.envFromSecret | string | `""` | The name of an existing Secret that contains sensitive environment variables passed to beat pods. |
 | studioBeat.envVars | object | `{}` | Additional environment variables for beat pods |
-| studioDvcxWorker | object | `{"affinity":{},"autoscaling":{"enabled":false,"maxReplicas":5,"minReplicas":1,"targetCPUUtilizationPercentage":80},"envFromSecret":"","envVars":{},"ephemeralStorage":{"persistentVolumeClaim":{"storageClass":""},"sizeLimit":"1Gi","type":"emptyDir"},"image":{"pullPolicy":"IfNotPresent","repository":"docker.iterative.ai/studio-backend"},"nodeSelector":{},"podAnnotations":{},"podSecurityContext":{},"replicaCount":1,"resources":{"limits":{"cpu":"8000m","ephemeral-storage":"10Gi","memory":"16Gi"},"requests":{"cpu":"500m","ephemeral-storage":"500Mi","memory":"512Mi"}},"securityContext":{},"tolerations":[]}` | Studio DVCx Worker settings group |
+| studioDvcxWorker | object | `{"affinity":{},"autoscaling":{"enabled":false,"maxReplicas":5,"minReplicas":1,"targetCPUUtilizationPercentage":80},"envFromSecret":"","envVars":{},"ephemeralStorage":{"persistentVolumeClaim":{"storageClass":""},"sizeLimit":"1Gi","type":"emptyDir"},"image":{"pullPolicy":"IfNotPresent","repository":"docker.iterative.ai/studio-dvcx-worker"},"nodeSelector":{},"podAnnotations":{},"podSecurityContext":{},"replicaCount":1,"resources":{"limits":{"cpu":"8000m","ephemeral-storage":"10Gi","memory":"16Gi"},"requests":{"cpu":"500m","ephemeral-storage":"500Mi","memory":"512Mi"}},"securityContext":{},"tolerations":[]}` | Studio DVCx Worker settings group |
 | studioDvcxWorker.affinity | object | `{}` | DVCx worker pod affinity configuration |
 | studioDvcxWorker.autoscaling | object | `{"enabled":false,"maxReplicas":5,"minReplicas":1,"targetCPUUtilizationPercentage":80}` | DVCx worker autoscaling configuration |
 | studioDvcxWorker.autoscaling.enabled | bool | `false` | DVCx worker autoscaling enabled flag |
@@ -128,9 +128,11 @@ A Helm chart for Kubernetes
 | studioDvcxWorker.ephemeralStorage | object | `{"persistentVolumeClaim":{"storageClass":""},"sizeLimit":"1Gi","type":"emptyDir"}` | Ephemeral storage configuration |
 | studioDvcxWorker.ephemeralStorage.persistentVolumeClaim | object | `{"storageClass":""}` | Persistent Volume Claim configuration for ephemeral storage |
 | studioDvcxWorker.ephemeralStorage.persistentVolumeClaim.storageClass | string | `""` | Persistent Volume Claim `storageClass` name, by default it will use the default `storageClass` |
+| studioDvcxWorker.ephemeralStorage.sizeLimit | string | `"1Gi"` | Ephemeral Storage size limit |
 | studioDvcxWorker.ephemeralStorage.type | string | `"emptyDir"` | Ephemeral Storage type. Possible values: `emptyDir`, `pvc` |
-| studioDvcxWorker.image | object | `{"pullPolicy":"IfNotPresent","repository":"docker.iterative.ai/studio-backend"}` | DVCx worker image settings |
-| studioDvcxWorker.image.repository | string | `"docker.iterative.ai/studio-backend"` | DVCx worker image repository |
+| studioDvcxWorker.image | object | `{"pullPolicy":"IfNotPresent","repository":"docker.iterative.ai/studio-dvcx-worker"}` | DVCx worker image settings |
+| studioDvcxWorker.image.pullPolicy | string | `"IfNotPresent"` | DVCx worker image pull policy |
+| studioDvcxWorker.image.repository | string | `"docker.iterative.ai/studio-dvcx-worker"` | DVCx worker image repository |
 | studioDvcxWorker.nodeSelector | object | `{}` | DVCx worker pod node selector configuration |
 | studioDvcxWorker.podAnnotations | object | `{}` | Additional DVCx worker pod annotations |
 | studioDvcxWorker.podSecurityContext | object | `{}` | DVCx worker pod security context configuration |
@@ -142,7 +144,7 @@ A Helm chart for Kubernetes
 | studioUi | object | `{"affinity":{},"autoscaling":{"enabled":false,"maxReplicas":5,"minReplicas":1,"targetCPUUtilizationPercentage":80},"envFromSecret":"","envVars":{},"fullnameOverride":"","image":{"pullPolicy":"IfNotPresent","repository":"docker.iterative.ai/studio-frontend"},"nameOverride":"","nodeSelector":{},"podAnnotations":{},"podSecurityContext":{},"replicaCount":1,"resources":{"limits":{"cpu":"1000m","memory":"2Gi"},"requests":{"cpu":"500m","memory":"1Gi"}},"securityContext":{},"service":{"port":3000,"type":"ClusterIP"},"tolerations":[]}` | Studio UI settings group |
 | studioUi.envFromSecret | string | `""` | The name of an existing Secret that contains sensitive environment variables passed to UI pods. |
 | studioUi.envVars | object | `{}` | Additional environment variables for ui pods |
-| studioWorker | object | `{"affinity":{},"autoscaling":{"enabled":false,"maxReplicas":5,"minReplicas":1,"targetCPUUtilizationPercentage":80},"envFromSecret":"","envVars":{},"nodeSelector":{},"podAnnotations":{},"podSecurityContext":{},"replicaCount":1,"resources":{"limits":{"cpu":"1000m","memory":"1Gi"},"requests":{"cpu":"500m","memory":"512Mi"}},"securityContext":{},"tolerations":[]}` | Studio Worker settings group |
+| studioWorker | object | `{"affinity":{},"autoscaling":{"enabled":false,"maxReplicas":5,"minReplicas":1,"targetCPUUtilizationPercentage":80},"envFromSecret":"","envVars":{},"image":{"pullPolicy":"IfNotPresent","repository":"docker.iterative.ai/studio-backend"},"nodeSelector":{},"podAnnotations":{},"podSecurityContext":{},"replicaCount":1,"resources":{"limits":{"cpu":"1000m","memory":"1Gi"},"requests":{"cpu":"500m","memory":"512Mi"}},"securityContext":{},"tolerations":[]}` | Studio worker settings group |
 | studioWorker.affinity | object | `{}` | Worker affinity |
 | studioWorker.autoscaling | object | `{"enabled":false,"maxReplicas":5,"minReplicas":1,"targetCPUUtilizationPercentage":80}` | Worker autoscaling configuration |
 | studioWorker.autoscaling.enabled | bool | `false` | Worker autoscaling enabled flag |
@@ -151,6 +153,9 @@ A Helm chart for Kubernetes
 | studioWorker.autoscaling.targetCPUUtilizationPercentage | int | `80` | Worker autoscaling target CPU utilization percentage |
 | studioWorker.envFromSecret | string | `""` | The name of an existing Secret that contains sensitive environment variables passed to worker pods. |
 | studioWorker.envVars | object | `{}` | Additional environment variables for worker pods |
+| studioWorker.image | object | `{"pullPolicy":"IfNotPresent","repository":"docker.iterative.ai/studio-backend"}` | Studio worker image settings |
+| studioWorker.image.pullPolicy | string | `"IfNotPresent"` | Studio worker image pull policy |
+| studioWorker.image.repository | string | `"docker.iterative.ai/studio-backend"` | Studio worker image repository |
 | studioWorker.nodeSelector | object | `{}` | Worker node selector |
 | studioWorker.podAnnotations | object | `{}` | Additional worker pod annotations |
 | studioWorker.podSecurityContext | object | `{}` | Worker pod security context |

--- a/charts/studio/README.md
+++ b/charts/studio/README.md
@@ -1,6 +1,6 @@
 # studio
 
-![Version: 0.2.20](https://img.shields.io/badge/Version-0.2.20-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.21.0](https://img.shields.io/badge/AppVersion-v2.21.0-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.21.0](https://img.shields.io/badge/AppVersion-v2.21.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/charts/studio/templates/_helpers.tpl
+++ b/charts/studio/templates/_helpers.tpl
@@ -148,18 +148,6 @@ checksum/secret-studio: {{ include (print $.Template.BasePath "/secret-studio.ya
 {{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" .Values.dockerServer (printf "%s:%s" .Values.dockerUsername .Values.dockerPassword | b64enc) }}
 {{- end }}
 
-{{- define "studio.dvcx.configMap" -}}
-{{- $dvcx := .Values.global.dvcx | default dict }}
-{{- $dvcxClickhouse := $dvcx.clickHouse | default dict }}
-DQL_ROOT_DIR: {{ $dvcx.rootDir | default "/tmp" | quote }}
-DQL_CH_HOST: {{ $dvcxClickhouse.host | default "" | quote }}
-DQL_CH_DATABASE: {{ $dvcxClickhouse.database | default "" | quote }}
-DVCX_ROOT_DIR: {{ $dvcx.rootDir | default "/tmp" | quote }}
-DVCX_CH_HOST: {{ $dvcxClickhouse.host | default "" | quote }}
-DVCX_CH_DATABASE: {{ $dvcxClickhouse.database | default "" | quote }}
-{{- end }}
-
 {{- define "ingress.protocol" -}}
 http{{- if $.Values.global.ingress.tlsEnabled }}s{{- end}}
 {{- end }}
-

--- a/charts/studio/templates/_helpers.tpl
+++ b/charts/studio/templates/_helpers.tpl
@@ -50,8 +50,17 @@ helm.sh/chart: {{ include "studio.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-
 {{- end }}
+
+{{- define "studio-dvcx-worker.labels" -}}
+helm.sh/chart: {{ include "studio.chart" . }}
+{{ include "studio-dvcx-worker.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
 {{- define "studio-worker.labels" -}}
 helm.sh/chart: {{ include "studio.chart" . }}
 {{ include "studio-worker.selectorLabels" . }}
@@ -100,6 +109,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{- define "studio-beat.selectorLabels" -}}
 app.kubernetes.io/name: studio-beat
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "studio-dvcx-worker.selectorLabels" -}}
+app.kubernetes.io/name: studio-dvcx-worker
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 

--- a/charts/studio/templates/configmap-studio-backend.yaml
+++ b/charts/studio/templates/configmap-studio-backend.yaml
@@ -3,7 +3,6 @@ kind: ConfigMap
 metadata:
   name: studio-backend
 data:
-{{- include "studio.dvcx.configMap" . | indent 2}}
 {{- with .Values.studioBackend.envVars}}
 {{-  toYaml . | nindent 2 }}
 {{- end }}

--- a/charts/studio/templates/configmap-studio-dvcx-worker.yaml
+++ b/charts/studio/templates/configmap-studio-dvcx-worker.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: studio-backend
+  name: {{ .Release.Name }}-dvcx-worker
 data:
 {{- include "studio.dvcx.configMap" . | indent 2}}
-{{- with .Values.studioBackend.envVars}}
+{{- with .Values.studioDvcxWorker.envVars}}
 {{-  toYaml . | nindent 2 }}
 {{- end }}

--- a/charts/studio/templates/configmap-studio-dvcx-worker.yaml
+++ b/charts/studio/templates/configmap-studio-dvcx-worker.yaml
@@ -3,7 +3,6 @@ kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-dvcx-worker
 data:
-{{- include "studio.dvcx.configMap" . | indent 2}}
 {{- with .Values.studioDvcxWorker.envVars}}
 {{-  toYaml . | nindent 2 }}
 {{- end }}

--- a/charts/studio/templates/configmap-studio-worker.yaml
+++ b/charts/studio/templates/configmap-studio-worker.yaml
@@ -3,7 +3,6 @@ kind: ConfigMap
 metadata:
   name: studio-worker
 data:
-{{- include "studio.dvcx.configMap" . | indent 2}}
 {{- with .Values.studioWorker.envVars}}
 {{-  toYaml . | nindent 2 }}
 {{- end }}

--- a/charts/studio/templates/configmap-studio-worker.yaml
+++ b/charts/studio/templates/configmap-studio-worker.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: studio-worker
 data:
+{{- include "studio.dvcx.configMap" . | indent 2}}
 {{- with .Values.studioWorker.envVars}}
 {{-  toYaml . | nindent 2 }}
 {{- end }}
-{{- include "studio.dvcx.configMap" . | indent 2}}

--- a/charts/studio/templates/configmap-studio.yaml
+++ b/charts/studio/templates/configmap-studio.yaml
@@ -116,7 +116,7 @@ data:
   {{- end }}
 
   {{- $dvcx := .Values.global.dvcx | default dict }}
-  {{- $dvcxClickhouse := $dvcx.clickhouse | default dict }}
+  {{- $dvcxClickhouse := $dvcx.clickHouse | default dict }}
   DQL_ENABLED: {{ $dvcx.enabled | default "False" | quote }}
   DQL_UDF_ENABLED: {{ $dvcx.udfEnabled | default "False" | quote }}
   DVCX_ENABLED: {{ $dvcx.enabled | default "False" | quote }}

--- a/charts/studio/templates/configmap-studio.yaml
+++ b/charts/studio/templates/configmap-studio.yaml
@@ -118,7 +118,10 @@ data:
   {{- $dvcx := .Values.global.dvcx | default dict }}
   {{- $dvcxClickhouse := $dvcx.clickhouse | default dict }}
   DQL_ENABLED: {{ $dvcx.enabled | default "False" | quote }}
+  DQL_UDF_ENABLED: {{ $dvcx.udfEnabled | default "False" | quote }}
   DVCX_ENABLED: {{ $dvcx.enabled | default "False" | quote }}
+  DVCX_UDF_ENABLED: {{ $dvcx.udfEnabled | default "False" | quote }}
+
   DQL_ROOT_DIR: {{ $dvcx.rootDir | default "/tmp" | quote }}
   DQL_CH_HOST: {{ $dvcxClickhouse.host | default "" | quote }}
   DQL_CH_DATABASE: {{ $dvcxClickhouse.database | default "" | quote }}

--- a/charts/studio/templates/configmap-studio.yaml
+++ b/charts/studio/templates/configmap-studio.yaml
@@ -116,11 +116,12 @@ data:
   {{- end }}
 
   {{- $dvcx := .Values.global.dvcx | default dict }}
+  {{- $dvcxClickhouse := $dvcx.clickhouse | default dict }}
   DQL_ENABLED: {{ $dvcx.enabled | default "False" | quote }}
   DVCX_ENABLED: {{ $dvcx.enabled | default "False" | quote }}
   DQL_ROOT_DIR: {{ $dvcx.rootDir | default "/tmp" | quote }}
-  DQL_CH_HOST: {{ $dvcx.clickHouse.host | default "" | quote }}
-  DQL_CH_DATABASE: {{ $dvcx.clickhouse.database | default "" | quote }}
+  DQL_CH_HOST: {{ $dvcxClickhouse.host | default "" | quote }}
+  DQL_CH_DATABASE: {{ $dvcxClickhouse.database | default "" | quote }}
   DVCX_ROOT_DIR: {{ $dvcx.rootDir | default "/tmp" | quote }}
-  DVCX_CH_HOST: {{ $dvcx.clickhouse.host | default "" | quote }}
-  DVCX_CH_DATABASE: {{ $dvcx.clickhouse.database | default "" | quote }}
+  DVCX_CH_HOST: {{ $dvcxClickhouse.host | default "" | quote }}
+  DVCX_CH_DATABASE: {{ $dvcxClickhouse.database | default "" | quote }}

--- a/charts/studio/templates/configmap-studio.yaml
+++ b/charts/studio/templates/configmap-studio.yaml
@@ -118,4 +118,9 @@ data:
   {{- $dvcx := .Values.global.dvcx | default dict }}
   DQL_ENABLED: {{ $dvcx.enabled | default "False" | quote }}
   DVCX_ENABLED: {{ $dvcx.enabled | default "False" | quote }}
-
+  DQL_ROOT_DIR: {{ $dvcx.rootDir | default "/tmp" | quote }}
+  DQL_CH_HOST: {{ $dvcx.clickHouse.host | default "" | quote }}
+  DQL_CH_DATABASE: {{ $dvcx.clickhouse.database | default "" | quote }}
+  DVCX_ROOT_DIR: {{ $dvcx.rootDir | default "/tmp" | quote }}
+  DVCX_CH_HOST: {{ $dvcx.clickhouse.host | default "" | quote }}
+  DVCX_CH_DATABASE: {{ $dvcx.clickhouse.database | default "" | quote }}

--- a/charts/studio/templates/deployment-studio-dvcx-worker.yaml
+++ b/charts/studio/templates/deployment-studio-dvcx-worker.yaml
@@ -47,7 +47,7 @@ spec:
             - configMapRef:
                 name: studio
             - configMapRef:
-                name: studio-dvcx-worker
+                name: {{ .Release.Name }}-dvcx-worker
             - secretRef:
                 name: studio
             {{- if .Values.global.envFromSecret }}

--- a/charts/studio/templates/deployment-studio-dvcx-worker.yaml
+++ b/charts/studio/templates/deployment-studio-dvcx-worker.yaml
@@ -82,7 +82,7 @@ spec:
               spec:
                 accessModes: [ "ReadWriteOnce" ]
                 {{- if .Values.studioDvcxWorker.ephemeralStorage.persistentVolumeClaim.storageClass }}
-                storageClassName: "scratch-storage-class"
+                storageClassName: {{ .Values.studioDvcxWorker.ephemeralStorage.persistentVolumeClaim.storageClass }}
                 {{- end }}
                 resources:
                   requests:

--- a/charts/studio/templates/deployment-studio-dvcx-worker.yaml
+++ b/charts/studio/templates/deployment-studio-dvcx-worker.yaml
@@ -35,11 +35,7 @@ spec:
             {{- toYaml .Values.studioDvcxWorker.securityContext | nindent 12 }}
           image: "{{ .Values.studioDvcxWorker.image.repository }}:{{ .Values.studioDvcxWorker.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.studioDvcxWorker.image.pullPolicy }}
-          args: ["/app/bin/run_celery_worker.sh"]
-          ports:
-            - name: http
-              containerPort: 8000
-              protocol: TCP
+          args: ["/app/bin/run_celery_worker_udf.sh"]
           resources:
             {{- toYaml .Values.studioDvcxWorker.resources | nindent 12 }}
           env:

--- a/charts/studio/templates/deployment-studio-dvcx-worker.yaml
+++ b/charts/studio/templates/deployment-studio-dvcx-worker.yaml
@@ -35,7 +35,7 @@ spec:
             {{- toYaml .Values.studioDvcxWorker.securityContext | nindent 12 }}
           image: "{{ .Values.studioDvcxWorker.image.repository }}:{{ .Values.studioDvcxWorker.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.studioDvcxWorker.image.pullPolicy }}
-          args: ["/app/bin/run_celery_worker_udf.sh"]
+          args: ["/app/bin/worker_runners/dql-udf.sh"]
           resources:
             {{- toYaml .Values.studioDvcxWorker.resources | nindent 12 }}
           env:

--- a/charts/studio/templates/deployment-studio-dvcx-worker.yaml
+++ b/charts/studio/templates/deployment-studio-dvcx-worker.yaml
@@ -35,7 +35,7 @@ spec:
             {{- toYaml .Values.studioDvcxWorker.securityContext | nindent 12 }}
           image: "{{ .Values.studioDvcxWorker.image.repository }}:{{ .Values.studioDvcxWorker.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.studioDvcxWorker.image.pullPolicy }}
-          args: ["/app/bin/worker_runners/dql-udf.sh"]
+          args: ["/app/bin/run_celery_worker_udf.sh"]
           resources:
             {{- toYaml .Values.studioDvcxWorker.resources | nindent 12 }}
           env:

--- a/charts/studio/templates/deployment-studio-dvcx-worker.yaml
+++ b/charts/studio/templates/deployment-studio-dvcx-worker.yaml
@@ -1,0 +1,109 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{.Release.Name}}-dvcx-worker
+  labels:
+    {{- include "studio-dvcx-worker.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.studioDvcxWorker.autoscaling.enabled }}
+  replicas: {{ .Values.studioDvcxWorker.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "studio-dvcx-worker.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/configmap-studio-dvcx-worker: {{ include (print $.Template.BasePath "/configmap-studio-dvcx-worker.yaml") . | sha256sum }}
+        {{- include "studio.checksum" . | indent 8 }}
+        {{- with .Values.studioDvcxWorker.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "studio-dvcx-worker.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "studio.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.studioDvcxWorker.podSecurityContext | nindent 8 }}
+      containers:
+        - name: studio-dvcx-worker
+          securityContext:
+            {{- toYaml .Values.studioDvcxWorker.securityContext | nindent 12 }}
+          image: "{{ .Values.studioDvcxWorker.image.repository }}:{{ .Values.studioDvcxWorker.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.studioDvcxWorker.image.pullPolicy }}
+          args: ["/app/bin/run_celery_worker.sh"]
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.studioDvcxWorker.resources | nindent 12 }}
+          env:
+            - name: "NO_MIGRATE_DB"
+              value: "1"
+            - name: "WAIT_FOR_MIGRATIONS"
+              value: "1"
+          envFrom:
+            - configMapRef:
+                name: studio
+            - configMapRef:
+                name: studio-dvcx-worker
+            - secretRef:
+                name: studio
+            {{- if .Values.global.envFromSecret }}
+            - secretRef:
+                name: {{ .Values.global.envFromSecret }}
+            {{- end }}
+            {{- if .Values.studioDvcxWorker.envFromSecret }}
+            - secretRef:
+                name: {{ .Values.studioDvcxWorker.envFromSecret }}
+            {{- end }}
+          volumeMounts:
+            - name: blobvault
+              mountPath: /blobvault
+            - name: studio-ca-certificates
+              mountPath: /usr/local/share/ca-certificates
+            - name: tmp-ephemeral
+              mountPath: /tmp
+      volumes:
+        - name: blobvault
+          persistentVolumeClaim:
+            claimName: blobvault
+        - name: studio-ca-certificates
+          configMap:
+            name: studio-ca-certificates
+        - name: tmp-ephemeral
+          {{- if eq .Values.studioDvcxWorker.ephemeralStorage.type "pvc" }}
+          ephemeral:
+            volumeClaimTemplate:
+              metadata:
+                labels:
+                  type: {{.Release.Name}}-dvcx-worker
+              spec:
+                accessModes: [ "ReadWriteOnce" ]
+                {{- if .Values.studioDvcxWorker.ephemeralStorage.persistentVolumeClaim.storageClass }}
+                storageClassName: "scratch-storage-class"
+                {{- end }}
+                resources:
+                  requests:
+                    storage: {{ .Values.studioDvcxWorker.ephemeralStorage.sizeLimit }}
+          {{- else }}
+          emptyDir:
+            sizeLimit: {{ .Values.studioDvcxWorker.ephemeralStorage.sizeLimit }}
+          {{- end }}
+      {{- with .Values.studioDvcxWorker.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.studioDvcxWorker.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.studioDvcxWorker.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/studio/templates/deployment-studio-worker.yaml
+++ b/charts/studio/templates/deployment-studio-worker.yaml
@@ -5,10 +5,9 @@ metadata:
   labels:
     {{- include "studio-worker.labels" . | nindent 4 }}
 spec:
-{{/*  {{- if not .Values.studioWorker.autoscaling.enabled }}*/}}
-{{/*  replicas: {{ .Values.studioWorker.replicaCount }}*/}}
-{{/*  {{- end }}*/}}
-  replicas: 0
+  {{- if not .Values.studioWorker.autoscaling.enabled }}
+  replicas: {{ .Values.studioWorker.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "studio-worker.selectorLabels" . | nindent 6 }}
@@ -37,10 +36,6 @@ spec:
           image: "{{ .Values.studioBackend.image.repository }}:{{ .Values.studioBackend.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.studioBackend.image.pullPolicy }}
           args: ["/app/bin/run_celery_worker.sh"]
-          ports:
-            - name: http
-              containerPort: 8000
-              protocol: TCP
           resources:
             {{- toYaml .Values.studioWorker.resources | nindent 12 }}
           env:

--- a/charts/studio/templates/deployment-studio-worker.yaml
+++ b/charts/studio/templates/deployment-studio-worker.yaml
@@ -5,9 +5,10 @@ metadata:
   labels:
     {{- include "studio-worker.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.studioWorker.autoscaling.enabled }}
-  replicas: {{ .Values.studioWorker.replicaCount }}
-  {{- end }}
+{{/*  {{- if not .Values.studioWorker.autoscaling.enabled }}*/}}
+{{/*  replicas: {{ .Values.studioWorker.replicaCount }}*/}}
+{{/*  {{- end }}*/}}
+  replicas: 0
   selector:
     matchLabels:
       {{- include "studio-worker.selectorLabels" . | nindent 6 }}

--- a/charts/studio/templates/hpa-studio-dvcx-worker.yaml
+++ b/charts/studio/templates/hpa-studio-dvcx-worker.yaml
@@ -4,12 +4,12 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{.Release.Name}}-dvcx-worker
   labels:
-    {{- include "studio-worker.labels" . | nindent 4 }}
+    {{- include "studio-dvcx-worker.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: studio-worker
+    name: studio-dvcx-worker
   minReplicas: {{ .Values.studioDvcxWorker.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.studioDvcxWorker.autoscaling.maxReplicas }}
   metrics:

--- a/charts/studio/templates/hpa-studio-dvcx-worker.yaml
+++ b/charts/studio/templates/hpa-studio-dvcx-worker.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.studioDvcxWorker.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{.Release.Name}}-dvcx-worker
+  labels:
+    {{- include "studio-worker.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: studio-worker
+  minReplicas: {{ .Values.studioDvcxWorker.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.studioDvcxWorker.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.studioDvcxWorker.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.studioDvcxWorker.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.studioDvcxWorker.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.studioDvcxWorker.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -513,8 +513,17 @@ studioBeat:
 
   affinity: {}
 
-# -- Studio Worker settings group
+# -- Studio worker settings group
 studioWorker:
+  # -- Studio worker image settings
+  image:
+    # -- Studio worker image repository
+    repository: docker.iterative.ai/studio-backend
+    # -- Studio worker image pull policy
+    pullPolicy: IfNotPresent
+    # -- Overrides the image tag whose default is the chart appVersion.
+    # tag: "v1.34.0"
+
   # -- Additional environment variables for worker pods
   envVars: {}
   # Example:
@@ -579,8 +588,8 @@ studioDvcxWorker:
   # -- DVCx worker image settings
   image:
     # -- DVCx worker image repository
-    repository: docker.iterative.ai/studio-backend
-
+    repository: docker.iterative.ai/studio-dvcx-worker
+    # -- DVCx worker image pull policy
     pullPolicy: IfNotPresent
     # -- Overrides the image tag whose default is the chart appVersion.
     # tag: "v1.34.0"
@@ -614,11 +623,12 @@ studioDvcxWorker:
   ephemeralStorage:
     # -- Ephemeral Storage type. Possible values: `emptyDir`, `pvc`
     type: emptyDir
+    # -- Ephemeral Storage size limit
+    sizeLimit: 1Gi
     # -- Persistent Volume Claim configuration for ephemeral storage
     persistentVolumeClaim:
       # -- Persistent Volume Claim `storageClass` name, by default it will use the default `storageClass`
       storageClass: ""
-    sizeLimit: 1Gi
 
   # -- DVCx worker autoscaling configuration
   autoscaling:

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -206,6 +206,8 @@ nginx:
   - name: blobvault
     mountPath: /blobvault
 
+  # -- Nginx for blobvault configuration
+  # @default -- see in `values.yaml`
   serverBlock: |-
     server {
         listen       8080;
@@ -333,14 +335,15 @@ postgresql:
         # -- Postgres database
         database: iterativeai
 
+# -- Studio UI settings group
 studioUi:
-  # -- Studio: Additional environment variables for ui pods
+  # -- Additional environment variables for ui pods
   envVars: {}
   # Example:
   # envVars:
   #   DEBUG: "True"
 
-  # -- Studio: The name of an existing Secret that contains sensitive environment variables
+  # -- The name of an existing Secret that contains sensitive environment variables
   # passed to UI pods.
   envFromSecret: ""
 
@@ -394,18 +397,21 @@ studioUi:
 
   affinity: {}
 
+# -- Studio Backend settings group
 studioBackend:
-  # -- Studio: Additional environment variables for backend pods
+  # -- Additional environment variables for backend pods
   envVars: {}
   # Example:
   # envVars:
   #   DEBUG: "True"
 
-  # -- Studio: The name of an existing Secret that contains sensitive environment variables
+  # -- The name of an existing Secret that contains sensitive environment variables
   # passed to backend pods.
   envFromSecret: ""
 
+  # -- Number of replicas of backend pods
   replicaCount: 1
+
 
   image:
     repository: docker.iterative.ai/studio-backend
@@ -455,14 +461,15 @@ studioBackend:
 
   affinity: {}
 
+# -- Studio Beat settings group
 studioBeat:
-  # -- Studio: Additional environment variables for beat pods
+  # -- Additional environment variables for beat pods
   envVars: {}
   # Example:
   # envVars:
   #   DEBUG: "True"
 
-  # -- Studio: The name of an existing Secret that contains sensitive environment variables
+  # -- The name of an existing Secret that contains sensitive environment variables
   # passed to beat pods.
   envFromSecret: ""
 
@@ -506,43 +513,51 @@ studioBeat:
 
   affinity: {}
 
+# -- Studio Worker settings group
 studioWorker:
-  # -- Studio: Additional environment variables for worker pods
+  # -- Additional environment variables for worker pods
   envVars: {}
   # Example:
   # envVars:
   #   DEBUG: "True"
 
-  # -- Studio: The name of an existing Secret that contains sensitive environment variables
+  # -- The name of an existing Secret that contains sensitive environment variables
   # passed to worker pods.
   envFromSecret: ""
 
   replicaCount: 1
 
+  # -- Worker resources configuration
   resources:
+    # -- Worker resource requests configuration
     requests:
       cpu: 500m
       memory: 512Mi
+    # -- Worker resource limits configuration
     limits:
       cpu: 1000m
       memory: 1Gi
-
+  # -- Worker autoscaling configuration
   autoscaling:
+    # -- Worker autoscaling enabled flag
     enabled: false
+    # -- Worker autoscaling minimum replicas
     minReplicas: 1
+    # -- Worker autoscaling maximum replicas
     maxReplicas: 5
+    # -- Worker autoscaling target CPU utilization percentage
     targetCPUUtilizationPercentage: 80
+    # -- Worker autoscaling target memory utilization percentage
     # targetMemoryUtilizationPercentage: 80
 
-  nameOverride: ""
-
-  fullnameOverride: ""
-
+  # -- Additional worker pod annotations
   podAnnotations: {}
 
+  # -- Worker pod security context
   podSecurityContext: {}
     # fsGroup: 2000
 
+  # -- Worker security context
   securityContext: {}
     # capabilities:
     #   drop:
@@ -551,10 +566,96 @@ studioWorker:
     # runAsNonRoot: true
     # runAsUser: 1000
 
+  # -- Worker node selector
+  nodeSelector: {}
+  # -- Worker tolerations
+  tolerations: []
+  # -- Worker affinity
+  affinity: {}
+
+# -- Studio DVCx Worker settings group
+studioDvcxWorker:
+
+  # -- DVCx worker image settings
+  image:
+    # -- DVCx worker image repository
+    repository: docker.iterative.ai/studio-backend
+
+    pullPolicy: IfNotPresent
+    # -- Overrides the image tag whose default is the chart appVersion.
+    # tag: "v1.34.0"
+
+  # -- Additional environment variables for DVCx worker pods
+  envVars: {}
+  # Example:
+  # envVars:
+  #   DEBUG: "True"
+
+  # -- The name of an existing Secret that contains sensitive environment variables passed to DVCx
+  # worker pods.
+  envFromSecret: ""
+
+  replicaCount: 1
+
+  # -- DVCx worker resources configuration
+  resources:
+    # -- DVCx worker requests configuration
+    requests:
+      cpu: 500m
+      memory: 512Mi
+      ephemeral-storage: 500Mi
+    # -- DVCx worker limits configuration
+    limits:
+      cpu: 8000m
+      memory: 16Gi
+      ephemeral-storage: 10Gi
+
+  # -- Ephemeral storage configuration
+  ephemeralStorage:
+    # -- Ephemeral Storage type. Possible values: `emptyDir`, `pvc`
+    type: emptyDir
+    # -- Persistent Volume Claim configuration for ephemeral storage
+    persistentVolumeClaim:
+      # -- Persistent Volume Claim `storageClass` name, by default it will use the default `storageClass`
+      storageClass: ""
+    sizeLimit: 1Gi
+
+  # -- DVCx worker autoscaling configuration
+  autoscaling:
+    # -- DVCx worker autoscaling enabled flag
+    enabled: false
+    # -- DVCx worker autoscaling min replicas
+    minReplicas: 1
+    # -- DVCx worker autoscaling max replicas
+    maxReplicas: 5
+    # -- DVCx worker autoscaling target CPU utilization percentage
+    targetCPUUtilizationPercentage: 80
+    # -- DVCx worker autoscaling target memory utilization percentage
+    # targetMemoryUtilizationPercentage: 80
+
+  # -- Additional DVCx worker pod annotations
+  podAnnotations: {}
+
+  # -- DVCx worker pod security context configuration
+  podSecurityContext: {}
+  # fsGroup: 2000
+
+  # -- DVCx worker pod security context configuration
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+  # runAsUser: 1000
+
+  # -- DVCx worker pod node selector configuration
   nodeSelector: {}
 
+  # -- DVCx worker pod tolerations configuration
   tolerations: []
 
+  # -- DVCx worker pod affinity configuration
   affinity: {}
 
 serviceAccount:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -17,7 +17,7 @@ profiles:
   - name: local
     patches:
       - path: /deploy/helm/releases/0/valuesFiles/1
-        value: charts/studio/values-skaffold.yaml
+        value: charts/studio/values-local-dev.yaml
         op: add
   - name: ingress-docker-desktop
     activation:


### PR DESCRIPTION
This commit adds DVCx Worker deployment, 
with ephemeral-storage configuration, which allows for configuring:
* emptyDir
* pvcTemplate

Additionally:
* ~Temporary the base Studio worker is scaled to 0.~ 
* Added more documentation  to `studioWorker`
* Removed `studio:` prefixes from some docs

Closes https://github.com/iterative/itops/issues/2181