### PR TITLE
Mount blobvault in 'backend' deployment

### DIFF
--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: studio
 description: A Helm chart for Kubernetes
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "v2.24.0"
 maintainers:
   - name: iterative

--- a/charts/studio/README.md
+++ b/charts/studio/README.md
@@ -1,6 +1,6 @@
 # studio
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.24.0](https://img.shields.io/badge/AppVersion-v2.24.0-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.24.0](https://img.shields.io/badge/AppVersion-v2.24.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/charts/studio/templates/deployment-studio-backend.yaml
+++ b/charts/studio/templates/deployment-studio-backend.yaml
@@ -97,6 +97,8 @@ spec:
             failureThreshold: 5
             timeoutSeconds: 60
           volumeMounts:
+            - name: blobvault
+              mountPath: /blobvault
             - name: studio-ca-certificates
               mountPath: /usr/local/share/ca-certificates
           resources:
@@ -122,6 +124,9 @@ spec:
                 name: {{ .Values.studioBackend.envFromSecret }}
             {{- end }}
       volumes:
+        - name: blobvault
+          persistentVolumeClaim:
+            claimName: blobvault
         - name: studio-ca-certificates
           configMap:
             name: studio-ca-certificates


### PR DESCRIPTION
We've added upload files to the backend via GraphQL mutation in https://github.com/iterative/studio/pull/7121
Files uploading not working in k8s because `blobvault` PVC is mounted only in `worker` deployment, and now we do upload in `backend` pods too.