### PR TITLE
Set fsGroup and fsGroupChangePolicy for deploys

### DIFF
--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: studio
 description: A Helm chart for Kubernetes
 type: application
-version: 0.4.0
+version: 0.4.1
 appVersion: "v2.24.0"
 maintainers:
   - name: iterative

--- a/charts/studio/README.md
+++ b/charts/studio/README.md
@@ -1,6 +1,6 @@
 # studio
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.24.0](https://img.shields.io/badge/AppVersion-v2.24.0-informational?style=flat-square)
+![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.24.0](https://img.shields.io/badge/AppVersion-v2.24.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/charts/studio/templates/deployment-studio-backend.yaml
+++ b/charts/studio/templates/deployment-studio-backend.yaml
@@ -33,6 +33,8 @@ spec:
       serviceAccountName: {{ include "studio.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.studioBackend.podSecurityContext | nindent 8 }}
+        fsGroup: 103 # dvc
+        fsGroupChangePolicy: "OnRootMismatch"
       initContainers:
         - name: run-migrations
           securityContext: {{- toYaml .Values.studioBackend.securityContext | nindent 12 }}

--- a/charts/studio/templates/deployment-studio-backend.yaml
+++ b/charts/studio/templates/deployment-studio-backend.yaml
@@ -32,9 +32,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "studio.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.studioBackend.podSecurityContext | nindent 8 }}
-        fsGroup: 103 # dvc
+        fsGroup: 103
         fsGroupChangePolicy: "OnRootMismatch"
+        {{- with .Values.studioWorker.podSecurityContext }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       initContainers:
         - name: run-migrations
           securityContext: {{- toYaml .Values.studioBackend.securityContext | nindent 12 }}

--- a/charts/studio/templates/deployment-studio-beat.yaml
+++ b/charts/studio/templates/deployment-studio-beat.yaml
@@ -29,6 +29,8 @@ spec:
       serviceAccountName: {{ include "studio.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.studioBeat.podSecurityContext | nindent 8 }}
+        fsGroup: 103 # dvc
+        fsGroupChangePolicy: "OnRootMismatch"
       containers:
         - name: studio-beat
           securityContext:

--- a/charts/studio/templates/deployment-studio-beat.yaml
+++ b/charts/studio/templates/deployment-studio-beat.yaml
@@ -28,9 +28,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "studio.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.studioBeat.podSecurityContext | nindent 8 }}
-        fsGroup: 103 # dvc
+        fsGroup: 103
         fsGroupChangePolicy: "OnRootMismatch"
+        {{- with .Values.studioWorker.podSecurityContext }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       containers:
         - name: studio-beat
           securityContext:

--- a/charts/studio/templates/deployment-studio-dvcx-worker.yaml
+++ b/charts/studio/templates/deployment-studio-dvcx-worker.yaml
@@ -29,6 +29,8 @@ spec:
       serviceAccountName: {{ include "studio.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.studioDvcxWorker.podSecurityContext | nindent 8 }}
+        fsGroup: 103 # dvc
+        fsGroupChangePolicy: "OnRootMismatch"
       containers:
         - name: studio-dvcx-worker
           securityContext:

--- a/charts/studio/templates/deployment-studio-dvcx-worker.yaml
+++ b/charts/studio/templates/deployment-studio-dvcx-worker.yaml
@@ -28,9 +28,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "studio.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.studioDvcxWorker.podSecurityContext | nindent 8 }}
-        fsGroup: 103 # dvc
+        fsGroup: 103
         fsGroupChangePolicy: "OnRootMismatch"
+        {{- with .Values.studioWorker.podSecurityContext }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       containers:
         - name: studio-dvcx-worker
           securityContext:

--- a/charts/studio/templates/deployment-studio-ui.yaml
+++ b/charts/studio/templates/deployment-studio-ui.yaml
@@ -32,8 +32,6 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "studio.serviceAccountName" . }}
       securityContext:
-        fsGroup: 103
-        fsGroupChangePolicy: "OnRootMismatch"
         {{- with .Values.studioWorker.podSecurityContext }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/studio/templates/deployment-studio-ui.yaml
+++ b/charts/studio/templates/deployment-studio-ui.yaml
@@ -33,6 +33,8 @@ spec:
       serviceAccountName: {{ include "studio.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.studioUi.podSecurityContext | nindent 8 }}
+        fsGroup: 103 # dvc
+        fsGroupChangePolicy: "OnRootMismatch"
       containers:
         - name: studio-ui
           securityContext:

--- a/charts/studio/templates/deployment-studio-ui.yaml
+++ b/charts/studio/templates/deployment-studio-ui.yaml
@@ -32,9 +32,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "studio.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.studioUi.podSecurityContext | nindent 8 }}
-        fsGroup: 103 # dvc
+        fsGroup: 103
         fsGroupChangePolicy: "OnRootMismatch"
+        {{- with .Values.studioWorker.podSecurityContext }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       containers:
         - name: studio-ui
           securityContext:

--- a/charts/studio/templates/deployment-studio-worker.yaml
+++ b/charts/studio/templates/deployment-studio-worker.yaml
@@ -29,6 +29,8 @@ spec:
       serviceAccountName: {{ include "studio.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.studioWorker.podSecurityContext | nindent 8 }}
+        fsGroup: 103 # dvc
+        fsGroupChangePolicy: "OnRootMismatch"
       containers:
         - name: studio-worker
           securityContext:

--- a/charts/studio/templates/deployment-studio-worker.yaml
+++ b/charts/studio/templates/deployment-studio-worker.yaml
@@ -28,9 +28,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "studio.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.studioWorker.podSecurityContext | nindent 8 }}
-        fsGroup: 103 # dvc
+        fsGroup: 103
         fsGroupChangePolicy: "OnRootMismatch"
+        {{- with .Values.studioWorker.podSecurityContext }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       containers:
         - name: studio-worker
           securityContext:


### PR DESCRIPTION
There was a bug affecting those Longhorn CSI for the blobvault PVC. Studio would fail to write files to the blobvault because the container runs as non-root, and the PVC is owned by `root` and has default permissions of `755`. To work around this issue, I've added `fsGroup` and `fsGroupChangePolicy` so that the GID for the files in the volume mirrors the GID of the container user.