### PR TITLE
fix(dvcx-worker): Make `/blobvault` volume optional in DVCx Worker

### DIFF
--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: studio
 description: A Helm chart for Kubernetes
 type: application
-version: 0.6.4
+version: 0.6.5
 appVersion: "v2.29.0"
 maintainers:
   - name: iterative

--- a/charts/studio/README.md
+++ b/charts/studio/README.md
@@ -1,6 +1,6 @@
 # studio
 
-![Version: 0.6.4](https://img.shields.io/badge/Version-0.6.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.29.0](https://img.shields.io/badge/AppVersion-v2.29.0-informational?style=flat-square)
+![Version: 0.6.5](https://img.shields.io/badge/Version-0.6.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.29.0](https://img.shields.io/badge/AppVersion-v2.29.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/charts/studio/templates/deployment-studio-dvcx-worker.yaml
+++ b/charts/studio/templates/deployment-studio-dvcx-worker.yaml
@@ -71,16 +71,20 @@ spec:
                 name: {{ .Values.studioDvcxWorker.envFromSecret }}
             {{- end }}
           volumeMounts:
+            {{- if not .Values.global.blobvault.bucket }}
             - name: blobvault
               mountPath: /blobvault
+            {{- end }}
             - name: studio-ca-certificates
               mountPath: /usr/local/share/ca-certificates
             - name: tmp-ephemeral
               mountPath: /tmp
       volumes:
+        {{- if not .Values.global.blobvault.bucket }}
         - name: blobvault
           persistentVolumeClaim:
             claimName: blobvault
+        {{- end }}
         - name: studio-ca-certificates
           configMap:
             name: studio-ca-certificates

--- a/charts/studio/templates/hpa-studio-backend.yaml
+++ b/charts/studio/templates/hpa-studio-backend.yaml
@@ -13,14 +13,6 @@ spec:
   minReplicas: {{ .Values.studioBackend.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.studioBackend.autoscaling.maxReplicas }}
   metrics:
-    {{- if .Values.studioBackend.autoscaling.targetCPUUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: {{ .Values.studioBackend.autoscaling.targetCPUUtilizationPercentage }}
-    {{- end }}
     {{- if .Values.studioBackend.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
@@ -28,5 +20,13 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.studioBackend.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.studioBackend.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.studioBackend.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
 {{- end }}

--- a/charts/studio/templates/hpa-studio-beat.yaml
+++ b/charts/studio/templates/hpa-studio-beat.yaml
@@ -13,14 +13,6 @@ spec:
   minReplicas: {{ .Values.studioBeat.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.studioBeat.autoscaling.maxReplicas }}
   metrics:
-    {{- if .Values.studioBeat.autoscaling.targetCPUUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: {{ .Values.studioBeat.autoscaling.targetCPUUtilizationPercentage }}
-    {{- end }}
     {{- if .Values.studioBeat.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
@@ -28,5 +20,13 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.studioBeat.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.studioBeat.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.studioBeat.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
 {{- end }}

--- a/charts/studio/templates/hpa-studio-dvcx-worker.yaml
+++ b/charts/studio/templates/hpa-studio-dvcx-worker.yaml
@@ -18,14 +18,6 @@ spec:
   maxReplicas: 0
   {{- end}}
   metrics:
-    {{- if .Values.studioDvcxWorker.autoscaling.targetCPUUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: {{ .Values.studioDvcxWorker.autoscaling.targetCPUUtilizationPercentage }}
-    {{- end }}
     {{- if .Values.studioDvcxWorker.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
@@ -33,5 +25,13 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.studioDvcxWorker.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.studioDvcxWorker.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.studioDvcxWorker.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
 {{- end }}

--- a/charts/studio/templates/hpa-studio-ui.yaml
+++ b/charts/studio/templates/hpa-studio-ui.yaml
@@ -13,14 +13,6 @@ spec:
   minReplicas: {{ .Values.studioUi.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.studioUi.autoscaling.maxReplicas }}
   metrics:
-    {{- if .Values.studioUi.autoscaling.targetCPUUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: {{ .Values.studioUi.autoscaling.targetCPUUtilizationPercentage }}
-    {{- end }}
     {{- if .Values.studioUi.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
@@ -28,5 +20,13 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.studioUi.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.studioUi.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.studioUi.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
 {{- end }}

--- a/charts/studio/templates/hpa-studio-worker.yaml
+++ b/charts/studio/templates/hpa-studio-worker.yaml
@@ -13,14 +13,6 @@ spec:
   minReplicas: {{ .Values.studioWorker.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.studioWorker.autoscaling.maxReplicas }}
   metrics:
-    {{- if .Values.studioWorker.autoscaling.targetCPUUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: {{ .Values.studioWorker.autoscaling.targetCPUUtilizationPercentage }}
-    {{- end }}
     {{- if .Values.studioWorker.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
@@ -28,5 +20,13 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.studioWorker.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.studioWorker.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.studioWorker.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
If there is no bucket set, use `/blobvault`. Otherwise don't mount it.

Also change order of HPA rules - ArgoCD  were HPA as a Out of Sync