### PR TITLE
Update leaked_secrets_scan.yaml

### DIFF
--- a/.github/workflows/leaked_secrets_scan.yaml
+++ b/.github/workflows/leaked_secrets_scan.yaml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: TruffleHog OSS
-        uses: trufflesecurity/trufflehog@ade5d91d5ca94e996377b1909a802dd9dbc51b6b
+        uses: trufflesecurity/trufflehog@v3.56.1
         with:
           path: ./
           base: ${{ github.event.repository.default_branch }}


### PR DESCRIPTION
With @0x2b3bfa0 yesterday we noticed, that action is using latest tag of the docker, so pinning does not make sense except spam made by renovate :(

https://github.com/trufflesecurity/trufflehog/blob/f9ea22f72bf1f4c052ffb56d80b3d481be1e0f9e/action.yml#L25

Tags are not bumped so frequently, as commits.