### PR TITLE
feat(ui): Set the INTERNAL_API_URL for accessing API from UI pods

### DIFF
--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: studio
 description: A Helm chart for Kubernetes
 type: application
-version: 0.7.3
+version: 0.7.4
 appVersion: "v2.45.1"
 maintainers:
   - name: iterative

--- a/charts/studio/README.md
+++ b/charts/studio/README.md
@@ -1,6 +1,6 @@
 # studio
 
-![Version: 0.7.3](https://img.shields.io/badge/Version-0.7.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.45.1](https://img.shields.io/badge/AppVersion-v2.45.1-informational?style=flat-square)
+![Version: 0.7.4](https://img.shields.io/badge/Version-0.7.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.45.1](https://img.shields.io/badge/AppVersion-v2.45.1-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/charts/studio/templates/configmap-studio-ui.yaml
+++ b/charts/studio/templates/configmap-studio-ui.yaml
@@ -3,6 +3,9 @@ kind: ConfigMap
 metadata:
   name: studio-ui
 data:
+
+  INTERNAL_API_URL: "http://studio-backend:8080{{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}/{{ include "studio.basePath" . }}{{- end }}/api"
+
 {{- with .Values.studioUi.envVars}}
 {{-  toYaml . | nindent 2 }}
 {{- end }}


### PR DESCRIPTION
In the last release we introduced a new ENV setting, that ensures that the Studio UI uses internal kubernetes network for calls between Node server and API