### PR TITLE
fix(ui) Update pod security context value referencein Studio UI

### DIFF
--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: studio
 description: A Helm chart for Kubernetes
 type: application
-version: 0.9.1
+version: 0.9.2
 appVersion: "v2.72.0"
 maintainers:
   - name: iterative

--- a/charts/studio/README.md
+++ b/charts/studio/README.md
@@ -1,6 +1,6 @@
 # studio
 
-![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.73.0](https://img.shields.io/badge/AppVersion-v2.73.0-informational?style=flat-square)
+![Version: 0.9.2](https://img.shields.io/badge/Version-0.9.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.72.0](https://img.shields.io/badge/AppVersion-v2.72.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/charts/studio/templates/deployment-studio-ui.yaml
+++ b/charts/studio/templates/deployment-studio-ui.yaml
@@ -32,7 +32,7 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "studio.serviceAccountName" . }}
       securityContext:
-        {{- with .Values.studioWorker.podSecurityContext }}
+        {{- with .Values.studioUi.podSecurityContext }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       containers:


### PR DESCRIPTION
The pod security context has been updated to use .Values.studioUi.podSecurityContext instead of .Values.studioWorker.podSecurityContext in the deployment-studio-ui.yaml file. In addition, the version of the studio chart has been incremented from 0.9.1 to 0.9.2.