### PR TITLE
feat(dvcx-worker): Add support for RWX PersistenceVolumeClaim

### DIFF
--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: studio
 description: A Helm chart for Kubernetes
 type: application
-version: 0.9.32
+version: 0.10.0
 appVersion: "v2.85.2"
 maintainers:
   - name: iterative

--- a/charts/studio/README.md
+++ b/charts/studio/README.md
@@ -1,6 +1,6 @@
 # studio
 
-![Version: 0.9.32](https://img.shields.io/badge/Version-0.9.32-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.85.2](https://img.shields.io/badge/AppVersion-v2.85.2-informational?style=flat-square)
+![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.85.2](https://img.shields.io/badge/AppVersion-v2.85.2-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -136,7 +136,7 @@ A Helm chart for Kubernetes
 | studioBlobvault.image | object | `{"repository":"nginx","tag":"1.25.1-alpine"}` | Image to use for the blobvault service |
 | studioBlobvault.image.repository | string | `"nginx"` | Image repository |
 | studioBlobvault.image.tag | string | `"1.25.1-alpine"` | Image tag |
-| studioDvcxWorker | object | `{"affinity":{},"autoscaling":{"enabled":false,"maxReplicas":5,"minReplicas":1,"targetCPUUtilizationPercentage":80},"envFromSecret":"","envVars":{},"ephemeralStorage":{"persistentVolumeClaim":{"storageClass":""},"size":"20Gi","type":"emptyDir"},"image":{"pullPolicy":"IfNotPresent","repository":"docker.iterative.ai/studio-dvcx-worker"},"logLevel":"info","nodeSelector":{},"podAnnotations":{},"podSecurityContext":{},"replicaCount":1,"resources":{"limits":{"ephemeral-storage":"20Gi","memory":"16Gi"},"requests":{"cpu":"1000m","ephemeral-storage":"10Gi","memory":"3Gi"}},"securityContext":{},"serviceAccount":{"annotations":{},"create":false,"name":""},"strategy":{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0}},"tolerations":[]}` | Studio DVCx Worker settings group |
+| studioDvcxWorker | object | `{"affinity":{},"autoscaling":{"enabled":false,"maxReplicas":5,"minReplicas":1,"targetCPUUtilizationPercentage":80},"envFromSecret":"","envVars":{},"ephemeralStorage":{"persistentVolumeClaim":{"claimName":"dvcx-worker","storageClass":""},"size":"20Gi","type":"ephemeral"},"image":{"pullPolicy":"IfNotPresent","repository":"docker.iterative.ai/studio-dvcx-worker"},"logLevel":"info","nodeSelector":{},"podAnnotations":{},"podSecurityContext":{},"replicaCount":1,"resources":{"limits":{"ephemeral-storage":"20Gi","memory":"16Gi"},"requests":{"cpu":"1000m","ephemeral-storage":"10Gi","memory":"3Gi"}},"securityContext":{},"serviceAccount":{"annotations":{},"create":false,"name":""},"strategy":{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0}},"tolerations":[]}` | Studio DVCx Worker settings group |
 | studioDvcxWorker.affinity | object | `{}` | DVCx worker pod affinity configuration |
 | studioDvcxWorker.autoscaling | object | `{"enabled":false,"maxReplicas":5,"minReplicas":1,"targetCPUUtilizationPercentage":80}` | DVCx worker autoscaling configuration |
 | studioDvcxWorker.autoscaling.enabled | bool | `false` | DVCx worker autoscaling enabled flag |
@@ -145,11 +145,12 @@ A Helm chart for Kubernetes
 | studioDvcxWorker.autoscaling.targetCPUUtilizationPercentage | int | `80` | DVCx worker autoscaling target CPU utilization percentage |
 | studioDvcxWorker.envFromSecret | string | `""` | The name of an existing Secret that contains sensitive environment variables passed to DVCx worker pods. |
 | studioDvcxWorker.envVars | object | `{}` | Additional environment variables for DVCx worker pods |
-| studioDvcxWorker.ephemeralStorage | object | `{"persistentVolumeClaim":{"storageClass":""},"size":"20Gi","type":"emptyDir"}` | Ephemeral storage configuration |
-| studioDvcxWorker.ephemeralStorage.persistentVolumeClaim | object | `{"storageClass":""}` | Persistent Volume Claim configuration for ephemeral storage |
-| studioDvcxWorker.ephemeralStorage.persistentVolumeClaim.storageClass | string | `""` | Persistent Volume Claim `storageClass` name, by default it will use the default `storageClass` |
+| studioDvcxWorker.ephemeralStorage | object | `{"persistentVolumeClaim":{"claimName":"dvcx-worker","storageClass":""},"size":"20Gi","type":"ephemeral"}` | Ephemeral storage configuration |
+| studioDvcxWorker.ephemeralStorage.persistentVolumeClaim | object | `{"claimName":"dvcx-worker","storageClass":""}` | Persistent Volume Claim configuration for ephemeral storage |
+| studioDvcxWorker.ephemeralStorage.persistentVolumeClaim.claimName | string | `"dvcx-worker"` | Persistent Volume Claim name, to mount externally managed PVC (`ephemeralStorage.type` has to be set to `pvc`) |
+| studioDvcxWorker.ephemeralStorage.persistentVolumeClaim.storageClass | string | `""` | Persistent Volume Claim `storageClass` name, by default it will use the default `storageClass`(not used when `pvc` is set as type) |
 | studioDvcxWorker.ephemeralStorage.size | string | `"20Gi"` | Ephemeral Storage size |
-| studioDvcxWorker.ephemeralStorage.type | string | `"emptyDir"` | Ephemeral Storage type. Possible values: `emptyDir`, `pvc` |
+| studioDvcxWorker.ephemeralStorage.type | string | `"ephemeral"` | Ephemeral Storage type. Possible values: `emptyDir`,  `ephemeral`, `pvc`, `pvcRWX` |
 | studioDvcxWorker.image | object | `{"pullPolicy":"IfNotPresent","repository":"docker.iterative.ai/studio-dvcx-worker"}` | DVCx worker image settings |
 | studioDvcxWorker.image.pullPolicy | string | `"IfNotPresent"` | DVCx worker image pull policy |
 | studioDvcxWorker.image.repository | string | `"docker.iterative.ai/studio-dvcx-worker"` | DVCx worker image repository |

--- a/charts/studio/templates/deployment-studio-dvcx-worker.yaml
+++ b/charts/studio/templates/deployment-studio-dvcx-worker.yaml
@@ -99,12 +99,12 @@ spec:
           configMap:
             name: studio-ca-certificates
         - name: tmp-ephemeral
-          {{- if eq .Values.studioDvcxWorker.ephemeralStorage.type "pvc" }}
+          {{- if eq .Values.studioDvcxWorker.ephemeralStorage.type "ephemeral" }}
           ephemeral:
             volumeClaimTemplate:
               metadata:
                 labels:
-                  type: {{.Release.Name}}-dvcx-worker
+                  type: {{.Release.Name}}-{{ .Values.studioDvcxWorker.ephemeralStorage.persistentVolumeClaim.claimName }}
               spec:
                 accessModes: [ "ReadWriteOnce" ]
                 {{- if .Values.studioDvcxWorker.ephemeralStorage.persistentVolumeClaim.storageClass }}
@@ -113,7 +113,13 @@ spec:
                 resources:
                   requests:
                     storage: {{ .Values.studioDvcxWorker.ephemeralStorage.size }}
-          {{- else }}
+          {{- else if eq .Values.studioDvcxWorker.ephemeralStorage.type "pvc" }}
+          persistentVolumeClaim:
+              claimName: {{ .Values.studioDvcxWorker.ephemeralStorage.persistentVolumeClaim.claimName }}
+          {{- else if eq .Values.studioDvcxWorker.ephemeralStorage.type "pvcRWX" }}
+          persistentVolumeClaim:
+              claimName: {{.Release.Name}}-studio-dvcx-worker-ephemeral-rwx
+          {{- else if eq .Values.studioDvcxWorker.ephemeralStorage.type "emptyDir"}}
           emptyDir:
             sizeLimit: {{ .Values.studioDvcxWorker.ephemeralStorage.size }}
           {{- end }}

--- a/charts/studio/templates/pvc-studio-dvcx-worker.yaml
+++ b/charts/studio/templates/pvc-studio-dvcx-worker.yaml
@@ -1,0 +1,15 @@
+{{- if eq .Values.studioDvcxWorker.ephemeralStorage.type "pvcRWX" }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{.Release.Name}}-studio-dvcx-worker-ephemeral-rwx
+  labels:
+    {{- include "studio-dvcx-worker.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: {{ .Values.studioDvcxWorker.ephemeralStorage.persistentVolumeClaim.storageClass }}
+  resources:
+    requests:
+      storage:  {{ .Values.studioDvcxWorker.ephemeralStorage.size }}
+{{- end }}

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -654,13 +654,15 @@ studioDvcxWorker:
 
   # -- Ephemeral storage configuration
   ephemeralStorage:
-    # -- Ephemeral Storage type. Possible values: `emptyDir`, `pvc`
-    type: emptyDir
+    # -- Ephemeral Storage type. Possible values: `emptyDir`,  `ephemeral`, `pvc`, `pvcRWX`
+    type: ephemeral
     # -- Ephemeral Storage size
     size: 20Gi
     # -- Persistent Volume Claim configuration for ephemeral storage
     persistentVolumeClaim:
-      # -- Persistent Volume Claim `storageClass` name, by default it will use the default `storageClass`
+      # -- Persistent Volume Claim name, to mount externally managed PVC (`ephemeralStorage.type` has to be set to `pvc`)
+      claimName: "dvcx-worker"
+      # -- Persistent Volume Claim `storageClass` name, by default it will use the default `storageClass`(not used when `pvc` is set as type)
       storageClass: ""
 
   # -- DVCx worker deployment strategy


### PR DESCRIPTION
This PR adds support for creating and mounting PVC with `RWX`(ReadWriteMany) access mode. In GKE it is allowed by use `enterprise-multishare-rwx`