### PR TITLE
Set client_max_body_size in global nginx config

### DIFF
--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: studio
 description: A Helm chart for Kubernetes
 type: application
-version: 0.9.32
+version: 0.9.33
 appVersion: "v2.85.2"
 maintainers:
   - name: iterative

--- a/charts/studio/README.md
+++ b/charts/studio/README.md
@@ -1,6 +1,6 @@
 # studio
 
-![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.85.2](https://img.shields.io/badge/AppVersion-v2.85.2-informational?style=flat-square)
+![Version: 0.10.1](https://img.shields.io/badge/Version-0.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.85.2](https://img.shields.io/badge/AppVersion-v2.85.2-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/charts/studio/nginx/nginx.conf
+++ b/charts/studio/nginx/nginx.conf
@@ -28,6 +28,7 @@ http {
 
   gzip  on;
 
+  client_max_body_size 100M;
 
   include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
There's a 30 MB file upload limit in Studio. However, because we proxy everything through the nginx sidecars, it was reduced to nginx's default value of 1 MB. To work around this, let's bump it to 100 MB.