### PR TITLE
Remove `--atomic`  parameter from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ To update the existing Studio deployment, run the following commands
 
 ```bash
 $ helm dependency update
-$ helm upgrade --install --atomic studio studio/ --namespace studio -f override.yaml
+$ helm upgrade --install studio studio/ --namespace studio -f override.yaml
 ```
 
 ## Uninstall Studio


### PR DESCRIPTION
It was causing more confusion when the deployment got stuck somewhere.