### PR TITLE
feat(dvcx): Add `pythonUserBase` path to DVCx worker config

### DIFF
--- a/charts/studio/Chart.lock
+++ b/charts/studio/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 18.12.1
+  version: 17.14.3
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 11.9.13
 - name: kuberay-operator
   repository: https://ray-project.github.io/kuberay-helm
   version: 0.6.0
-digest: sha256:f94abcda2079d7d57e920eacfe530f333050f628b2a31a0d17198be53a7f3d54
-generated: "2024-02-13T13:20:18.321969182Z"
+digest: sha256:11e47f1d691977c00cf3dd4454365b63ebdb81db484e837a1f720616a50fec63
+generated: "2023-08-18T21:39:06.308367+02:00"

--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: studio
 description: A Helm chart for Kubernetes
 type: application
-version: 0.10.3
+version: 0.10.4
 appVersion: "v2.85.5"
 maintainers:
   - name: iterative

--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -11,7 +11,7 @@ icon: "https://static.iterative.ai/logo/studio.svg"
 dependencies:
   - name: redis
     condition: redis.enabled
-    version: "18.12.1"
+    version: "17.14.3"
     repository: "https://charts.bitnami.com/bitnami"
   - name: postgresql
     condition: postgresql.enabled

--- a/charts/studio/README.md
+++ b/charts/studio/README.md
@@ -136,7 +136,7 @@ A Helm chart for Kubernetes
 | studioBlobvault.image | object | `{"repository":"nginx","tag":"1.25.1-alpine"}` | Image to use for the blobvault service |
 | studioBlobvault.image.repository | string | `"nginx"` | Image repository |
 | studioBlobvault.image.tag | string | `"1.25.1-alpine"` | Image tag |
-| studioDvcxWorker | object | `{"affinity":{},"autoscaling":{"enabled":false,"maxReplicas":5,"minReplicas":1,"targetCPUUtilizationPercentage":80},"envFromSecret":"","envVars":{},"ephemeralStorage":{"persistentVolumeClaim":{"claimName":"dvcx-worker","storageClass":""},"size":"20Gi","type":"ephemeral"},"image":{"pullPolicy":"IfNotPresent","repository":"docker.iterative.ai/studio-dvcx-worker"},"logLevel":"info","nodeSelector":{},"podAnnotations":{},"podSecurityContext":{},"replicaCount":1,"resources":{"limits":{"ephemeral-storage":"20Gi","memory":"16Gi"},"requests":{"cpu":"1000m","ephemeral-storage":"10Gi","memory":"3Gi"}},"securityContext":{},"serviceAccount":{"annotations":{},"create":false,"name":""},"strategy":{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0}},"tolerations":[]}` | Studio DVCx Worker settings group |
+| studioDvcxWorker | object | `{"affinity":{},"autoscaling":{"enabled":false,"maxReplicas":5,"minReplicas":1,"targetCPUUtilizationPercentage":80},"envFromSecret":"","envVars":{},"ephemeralStorage":{"persistentVolumeClaim":{"claimName":"dvcx-worker","storageClass":""},"size":"20Gi","type":"ephemeral"},"image":{"pullPolicy":"IfNotPresent","repository":"docker.iterative.ai/studio-dvcx-worker"},"logLevel":"info","nodeSelector":{},"podAnnotations":{},"podSecurityContext":{},"pythonUserBase":"/tmp/.pip/local","replicaCount":1,"resources":{"limits":{"ephemeral-storage":"20Gi","memory":"16Gi"},"requests":{"cpu":"1000m","ephemeral-storage":"10Gi","memory":"3Gi"}},"securityContext":{},"serviceAccount":{"annotations":{},"create":false,"name":""},"strategy":{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0}},"tolerations":[]}` | Studio DVCx Worker settings group |
 | studioDvcxWorker.affinity | object | `{}` | DVCx worker pod affinity configuration |
 | studioDvcxWorker.autoscaling | object | `{"enabled":false,"maxReplicas":5,"minReplicas":1,"targetCPUUtilizationPercentage":80}` | DVCx worker autoscaling configuration |
 | studioDvcxWorker.autoscaling.enabled | bool | `false` | DVCx worker autoscaling enabled flag |
@@ -158,6 +158,7 @@ A Helm chart for Kubernetes
 | studioDvcxWorker.nodeSelector | object | `{}` | DVCx worker pod node selector configuration |
 | studioDvcxWorker.podAnnotations | object | `{}` | Additional DVCx worker pod annotations |
 | studioDvcxWorker.podSecurityContext | object | `{}` | DVCx worker pod security context configuration |
+| studioDvcxWorker.pythonUserBase | string | `"/tmp/.pip/local"` | DVCx worker libraries base path |
 | studioDvcxWorker.resources | object | `{"limits":{"ephemeral-storage":"20Gi","memory":"16Gi"},"requests":{"cpu":"1000m","ephemeral-storage":"10Gi","memory":"3Gi"}}` | DVCx worker resources configuration |
 | studioDvcxWorker.resources.limits | object | `{"ephemeral-storage":"20Gi","memory":"16Gi"}` | DVCx worker limits configuration |
 | studioDvcxWorker.resources.requests | object | `{"cpu":"1000m","ephemeral-storage":"10Gi","memory":"3Gi"}` | DVCx worker requests configuration |

--- a/charts/studio/README.md
+++ b/charts/studio/README.md
@@ -1,6 +1,6 @@
 # studio
 
-![Version: 0.10.3](https://img.shields.io/badge/Version-0.10.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.85.5](https://img.shields.io/badge/AppVersion-v2.85.5-informational?style=flat-square)
+![Version: 0.10.4](https://img.shields.io/badge/Version-0.10.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.85.5](https://img.shields.io/badge/AppVersion-v2.85.5-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -158,7 +158,7 @@ A Helm chart for Kubernetes
 | studioDvcxWorker.nodeSelector | object | `{}` | DVCx worker pod node selector configuration |
 | studioDvcxWorker.podAnnotations | object | `{}` | Additional DVCx worker pod annotations |
 | studioDvcxWorker.podSecurityContext | object | `{}` | DVCx worker pod security context configuration |
-| studioDvcxWorker.pythonUserBase | string | `"/tmp/.pip/local"` | DVCx worker libraries base path |
+| studioDvcxWorker.pythonUserBase | string | `"/tmp/.pip/local"` | DVCx worker path to the base directory for the user site-packages. |
 | studioDvcxWorker.resources | object | `{"limits":{"ephemeral-storage":"20Gi","memory":"16Gi"},"requests":{"cpu":"1000m","ephemeral-storage":"10Gi","memory":"3Gi"}}` | DVCx worker resources configuration |
 | studioDvcxWorker.resources.limits | object | `{"ephemeral-storage":"20Gi","memory":"16Gi"}` | DVCx worker limits configuration |
 | studioDvcxWorker.resources.requests | object | `{"cpu":"1000m","ephemeral-storage":"10Gi","memory":"3Gi"}` | DVCx worker requests configuration |

--- a/charts/studio/README.md
+++ b/charts/studio/README.md
@@ -15,7 +15,7 @@ A Helm chart for Kubernetes
 | Repository | Name | Version |
 |------------|------|---------|
 | https://charts.bitnami.com/bitnami | postgresql | 11.9.13 |
-| https://charts.bitnami.com/bitnami | redis | 18.12.1 |
+| https://charts.bitnami.com/bitnami | redis | 17.14.3 |
 | https://ray-project.github.io/kuberay-helm | kuberay-operator | 0.6.0 |
 
 ## Values

--- a/charts/studio/templates/configmap-studio-dvcx-worker.yaml
+++ b/charts/studio/templates/configmap-studio-dvcx-worker.yaml
@@ -4,6 +4,8 @@ metadata:
   name: {{ .Release.Name }}-dvcx-worker
 data:
   CELERY_LOG_LEVEL: "{{ .Values.studioDvcxWorker.logLevel | default "info" | lower }}"
+  PYTHONUSERBASE: "{{ .Values.studioDvcxWorker.pythonUserBase | default "/tmp/.pip/local" }}"
+
 {{- with .Values.studioDvcxWorker.envVars}}
 {{-  toYaml . | nindent 2 }}
 {{- end }}

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -640,6 +640,9 @@ studioDvcxWorker:
   # -- DVCx worker log level
   logLevel: "info"
 
+  # -- DVCx worker path to the base directory for the user site-packages.
+  pythonUserBase: "/tmp/.pip/local"
+
   # -- DVCx worker resources configuration
   resources:
     # -- DVCx worker requests configuration


### PR DESCRIPTION
This update introduces a new parameter, `pythonUserBase`, to the DVCx worker configuration. This allows customization of the base path for user site-packages. By default the location is changed from `~/.local` to `/tmp/.pip/local`, where ephemeralStorage is beeing used.

Pip docs: https://pip.pypa.io/en/stable/user_guide/#user-installs

Closes https://github.com/iterative/itops/issues/3636

https://github.com/iterative/helm-charts/pull/305, which caused a bug similar to https://github.com/bitnami/charts/issues/20504
the whole `bitami/charts` repository introduced breaking changes, causing the issue. Probably, there is a need for upgrading `redis` & `postgres` in one PR.