### PR TITLE
Adjust ingress-nginx proxy body size

### DIFF
--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: studio
 description: A Helm chart for Kubernetes
 type: application
-version: 0.10.4
+version: 0.10.5
 appVersion: "v2.85.5"
 maintainers:
   - name: iterative

--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: studio
 description: A Helm chart for Kubernetes
 type: application
-version: 0.10.5
+version: 0.10.7
 appVersion: "v2.85.5"
 maintainers:
   - name: iterative

--- a/charts/studio/README.md
+++ b/charts/studio/README.md
@@ -1,6 +1,6 @@
 # studio
 
-![Version: 0.10.6](https://img.shields.io/badge/Version-0.10.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.88.0](https://img.shields.io/badge/AppVersion-v2.88.0-informational?style=flat-square)
+![Version: 0.10.7](https://img.shields.io/badge/Version-0.10.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.88.0](https://img.shields.io/badge/AppVersion-v2.88.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/charts/studio/templates/ingress-blobvault-nginx.yaml
+++ b/charts/studio/templates/ingress-blobvault-nginx.yaml
@@ -20,6 +20,7 @@ metadata:
   annotations:
     meta.helm.sh/release-name: {{ .Release.Name }}
     meta.helm.sh/release-namespace: {{.Release.Namespace}}
+    nginx.ingress.kubernetes.io/proxy-body-size: 100M
   {{- with .Values.global.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/studio/templates/ingress-studio-api.yaml
+++ b/charts/studio/templates/ingress-studio-api.yaml
@@ -19,6 +19,7 @@ metadata:
   annotations:
     meta.helm.sh/release-name: {{ .Release.Name }}
     meta.helm.sh/release-namespace: {{.Release.Namespace}}
+    nginx.ingress.kubernetes.io/proxy-body-size: 100M
   {{- with .Values.global.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
Follow up to https://github.com/iterative/helm-charts/pull/310. The previous PR only adjusted the proxy body size in the sidecar containers. However, we don't use the sidecars for non-basepath deployments. Rather, we use plain ingress objects. In the case of our VM variants, this is `ingress-nginx`, so let's set a reasonable default for it.