### PR TITLE
remove DVCX_ROOT_DIR variable

### DIFF
--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: studio
 description: A Helm chart for Kubernetes
 type: application
-version: 0.13.1
+version: 0.13.2
 appVersion: "v2.105.3"
 maintainers:
   - name: iterative

--- a/charts/studio/README.md
+++ b/charts/studio/README.md
@@ -1,6 +1,6 @@
 # studio
 
-![Version: 0.13.1](https://img.shields.io/badge/Version-0.13.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.105.3](https://img.shields.io/badge/AppVersion-v2.105.3-informational?style=flat-square)
+![Version: 0.13.2](https://img.shields.io/badge/Version-0.13.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.105.3](https://img.shields.io/badge/AppVersion-v2.105.3-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/charts/studio/templates/configmap-studio.yaml
+++ b/charts/studio/templates/configmap-studio.yaml
@@ -132,6 +132,5 @@ data:
   DVCX_RAY_URL: "http://{{ .Release.Name }}-ray-head-svc.{{ .Release.Namespace }}.svc.cluster.local:8265"
   {{- end }}
 
-  DVCX_ROOT_DIR: {{ $dvcx.rootDir | default "/tmp" | quote }}
   DVCX_CH_HOST: {{ $dvcxClickhouse.host | default "" | quote }}
   DVCX_CH_DATABASE: {{ $dvcxClickhouse.database | default "" | quote }}

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -82,8 +82,6 @@ global:
 
   # -- Studio: Settings related to DVCX
   dvcx: {}
-    # -- Place where DVCX will store its temporary files
-    # rootDir: "/tmp"
 
   ingress:
     enabled: true


### PR DESCRIPTION
Part of https://github.com/iterative/studio/issues/9470

Companion PRs: https://github.com/iterative/studio/pull/9592 / https://github.com/iterative/dvcx-server/pull/355

> `DVCX_ROOT_DIR=/tmp` — root directory for dvcx (see [here](https://github.com/iterative/dvcx/blob/ae69652c87fd754473b387414a7aa8912d6c8003/src/dvcx/utils.py#L39)), this variable can be removed since we are using `DVCX_UDF_DVCX_COMMON_DIR` setting (see [here](https://github.com/iterative/studio/blob/784c5379d7ac968deea52e3377b847947c6ee290/backend/dqlapp/tasks/query_script_runner.py#L323))

I'd like to remove `DVCX_UDF_DVCX_COMMON_DIR` but I don't think we can do that with this variable in place and even if `DVCX_UDF_DVCX_COMMON_DIR` is not removed it currently overwrites this variable so no point in having it.