### PR TITLE
Add support for self-hosted ClickHouse

### DIFF
--- a/.github/workflows/helm-lint-and-install.yaml
+++ b/.github/workflows/helm-lint-and-install.yaml
@@ -59,7 +59,7 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         run: |
           ct lint-and-install --target-branch ${{ github.event.repository.default_branch }} --upgrade --skip-missing-values --debug \
-          --helm-extra-set-args '--set ci=true --set global.blobvault.persistentVolume.storageClassName="standard" --set imagePullSecrets[0].name=iterativeai --set dockerUsername=${{ vars.ITERATIVE_DOCKER_REGISTRY_USER }} --set dockerPassword=${{ secrets.ITERATIVE_DOCKER_REGISTRY_PASSWORD }} --set dockerServer=docker.iterative.ai'
+          --helm-extra-set-args '--set ci=true --set global.blobvault.persistentVolume.storageClassName="standard" --set clickhouse.auth.password="clickhouse" --set imagePullSecrets[0].name=iterativeai --set dockerUsername=${{ vars.ITERATIVE_DOCKER_REGISTRY_USER }} --set dockerPassword=${{ secrets.ITERATIVE_DOCKER_REGISTRY_PASSWORD }} --set dockerServer=docker.iterative.ai'
 
   helm-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/helm-lint-and-install.yaml
+++ b/.github/workflows/helm-lint-and-install.yaml
@@ -59,7 +59,7 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         run: |
           ct lint-and-install --target-branch ${{ github.event.repository.default_branch }} --upgrade --skip-missing-values --debug \
-          --helm-extra-set-args '--set ci=true --set global.blobvault.persistentVolume.storageClassName="standard" --set clickhouse.auth.password="clickhouse" --set imagePullSecrets[0].name=iterativeai --set dockerUsername=${{ vars.ITERATIVE_DOCKER_REGISTRY_USER }} --set dockerPassword=${{ secrets.ITERATIVE_DOCKER_REGISTRY_PASSWORD }} --set dockerServer=docker.iterative.ai'
+          --helm-extra-set-args '--set ci=true --set global.blobvault.persistentVolume.storageClassName="standard" --set imagePullSecrets[0].name=iterativeai --set dockerUsername=${{ vars.ITERATIVE_DOCKER_REGISTRY_USER }} --set dockerPassword=${{ secrets.ITERATIVE_DOCKER_REGISTRY_PASSWORD }} --set dockerServer=docker.iterative.ai'
 
   helm-docs:
     runs-on: ubuntu-latest

--- a/charts/studio/Chart.lock
+++ b/charts/studio/Chart.lock
@@ -5,5 +5,8 @@ dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 11.9.13
-digest: sha256:4d64be3c68e02f9bf8d4468389b628383c33fc3e1902597f637c49ccf2f777d9
-generated: "2024-04-30T15:57:25.19756706Z"
+- name: clickhouse
+  repository: https://charts.bitnami.com/bitnami
+  version: 6.2.0
+digest: sha256:5764f9714b4d0e478f5ea25796091919f7ca334773989ac86235c7377db85405
+generated: "2024-06-01T16:58:57.386705962Z"

--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: studio
 description: A Helm chart for Kubernetes
 type: application
-version: 0.14.2
+version: 0.14.3
 appVersion: "v2.119.4"
 maintainers:
   - name: iterative
@@ -16,4 +16,8 @@ dependencies:
   - name: postgresql
     condition: postgresql.enabled
     version: "11.9.13"
+    repository: "https://charts.bitnami.com/bitnami"
+  - name: clickhouse
+    condition: clickhouse.enabled
+    version: "6.2.0"
     repository: "https://charts.bitnami.com/bitnami"

--- a/charts/studio/README.md
+++ b/charts/studio/README.md
@@ -22,7 +22,7 @@ A Helm chart for Kubernetes
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| clickhouse.auth.password | string | `"clickhouse"` | ClickHouse password |
+| clickhouse.auth.password | string | `""` | ClickHouse password |
 | clickhouse.enabled | bool | `false` | ClickHouse enabled |
 | clickhouse.fullnameOverride | string | `"studio-clickhouse"` | ClickHouse name override |
 | clickhouse.replicaCount | int | `1` |  |

--- a/charts/studio/README.md
+++ b/charts/studio/README.md
@@ -22,7 +22,7 @@ A Helm chart for Kubernetes
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| clickhouse.auth.password | string | `""` | ClickHouse password |
+| clickhouse.auth.password | string | `"clickhouse"` | ClickHouse password |
 | clickhouse.enabled | bool | `false` | ClickHouse enabled |
 | clickhouse.fullnameOverride | string | `"studio-clickhouse"` | ClickHouse name override |
 | clickhouse.replicaCount | int | `1` |  |

--- a/charts/studio/README.md
+++ b/charts/studio/README.md
@@ -22,8 +22,8 @@ A Helm chart for Kubernetes
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| clickhouse.auth.password | string | `"clickhouse"` |  |
-| clickhouse.auth.username | string | `"default"` |  |
+| clickhouse.auth.password | string | `"clickhouse"` | ClickHouse password |
+| clickhouse.auth.username | string | `"default"` | ClickHouse username |
 | clickhouse.enabled | bool | `false` | ClickHouse enabled |
 | clickhouse.fullnameOverride | string | `"studio-clickhouse"` | ClickHouse name override |
 | global.basePath | string | `""` | Studio: Base path (prefix) |

--- a/charts/studio/README.md
+++ b/charts/studio/README.md
@@ -26,9 +26,6 @@ A Helm chart for Kubernetes
 | clickhouse.auth.username | string | `"default"` |  |
 | clickhouse.enabled | bool | `false` | ClickHouse enabled |
 | clickhouse.fullnameOverride | string | `"studio-clickhouse"` | ClickHouse name override |
-| clickhouse.image.registry | string | `"docker.io"` |  |
-| clickhouse.image.repository | string | `"bitnami/clickhouse"` |  |
-| clickhouse.image.tag | string | `"24.4.1-debian-12-r4"` |  |
 | global.basePath | string | `""` | Studio: Base path (prefix) |
 | global.blobvault.accessKeyId | string | `""` | Blobvault S3 access key ID |
 | global.blobvault.bucket | string | `""` | Blobvault S3 bucket name |

--- a/charts/studio/README.md
+++ b/charts/studio/README.md
@@ -25,6 +25,8 @@ A Helm chart for Kubernetes
 | clickhouse.auth.password | string | `"clickhouse"` | ClickHouse password |
 | clickhouse.enabled | bool | `false` | ClickHouse enabled |
 | clickhouse.fullnameOverride | string | `"studio-clickhouse"` | ClickHouse name override |
+| clickhouse.replicaCount | int | `1` |  |
+| clickhouse.shards | int | `1` |  |
 | global.basePath | string | `""` | Studio: Base path (prefix) |
 | global.blobvault.accessKeyId | string | `""` | Blobvault S3 access key ID |
 | global.blobvault.bucket | string | `""` | Blobvault S3 bucket name |

--- a/charts/studio/README.md
+++ b/charts/studio/README.md
@@ -1,6 +1,6 @@
 # studio
 
-![Version: 0.14.2](https://img.shields.io/badge/Version-0.14.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.119.4](https://img.shields.io/badge/AppVersion-v2.119.4-informational?style=flat-square)
+![Version: 0.14.3](https://img.shields.io/badge/Version-0.14.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.119.4](https://img.shields.io/badge/AppVersion-v2.119.4-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -14,6 +14,7 @@ A Helm chart for Kubernetes
 
 | Repository | Name | Version |
 |------------|------|---------|
+| https://charts.bitnami.com/bitnami | clickhouse | 6.2.0 |
 | https://charts.bitnami.com/bitnami | postgresql | 11.9.13 |
 | https://charts.bitnami.com/bitnami | redis | 17.14.3 |
 
@@ -21,6 +22,13 @@ A Helm chart for Kubernetes
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| clickhouse.auth.password | string | `"clickhouse"` |  |
+| clickhouse.auth.username | string | `"default"` |  |
+| clickhouse.enabled | bool | `false` | ClickHouse enabled |
+| clickhouse.fullnameOverride | string | `"studio-clickhouse"` | ClickHouse name override |
+| clickhouse.image.registry | string | `"docker.io"` |  |
+| clickhouse.image.repository | string | `"bitnami/clickhouse"` |  |
+| clickhouse.image.tag | string | `"24.4.1-debian-12-r4"` |  |
 | global.basePath | string | `""` | Studio: Base path (prefix) |
 | global.blobvault.accessKeyId | string | `""` | Blobvault S3 access key ID |
 | global.blobvault.bucket | string | `""` | Blobvault S3 bucket name |

--- a/charts/studio/README.md
+++ b/charts/studio/README.md
@@ -23,7 +23,6 @@ A Helm chart for Kubernetes
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | clickhouse.auth.password | string | `"clickhouse"` | ClickHouse password |
-| clickhouse.auth.username | string | `"default"` | ClickHouse username |
 | clickhouse.enabled | bool | `false` | ClickHouse enabled |
 | clickhouse.fullnameOverride | string | `"studio-clickhouse"` | ClickHouse name override |
 | global.basePath | string | `""` | Studio: Base path (prefix) |

--- a/charts/studio/templates/secret-studio.yaml
+++ b/charts/studio/templates/secret-studio.yaml
@@ -75,9 +75,5 @@ stringData:
   {{- if $dvcxClickhouse.dsn }}
   DVCX_CH_DSN: {{ $dvcxClickhouse.dsn | quote }}
   {{- else if .Values.clickhouse.enabled }}
-  DVCX_CH_DSN:
-    clickhouse+native://
-    {{ .Values.clickhouse.auth.username }}:{{ .Values.clickhouse.auth.password }}@
-    {{ .Values.clickhouse.fullnameOverride }}.{{ .Release.Namespace }}.svc.cluster.local/
-    default?secure=False
+  DVCX_CH_DSN: clickhouse+native://{{ .Values.clickhouse.auth.username }}:{{ .Values.clickhouse.auth.password }}@{{ .Values.clickhouse.fullnameOverride }}.{{ .Release.Namespace }}.svc.cluster.local/default?secure=False
   {{- end }}

--- a/charts/studio/templates/secret-studio.yaml
+++ b/charts/studio/templates/secret-studio.yaml
@@ -75,7 +75,7 @@ stringData:
   {{- if $dvcxClickhouse.dsn }}
   DVCX_CH_DSN: {{ $dvcxClickhouse.dsn | quote }}
   {{- else if .Values.clickhouse.enabled }}
-  DVCX_CH_DSN: >
+  DVCX_CH_DSN:
     clickhouse+native://
     {{ .Values.clickhouse.auth.username }}:{{ .Values.clickhouse.auth.password }}@
     {{ .Values.clickhouse.fullnameOverride }}.{{ .Release.Namespace }}.svc.cluster.local/

--- a/charts/studio/templates/secret-studio.yaml
+++ b/charts/studio/templates/secret-studio.yaml
@@ -72,7 +72,7 @@ stringData:
 
   {{- $dvcx := .Values.global.dvcx | default dict }}
   {{- $dvcxClickhouse := $dvcx.clickHouse | default dict }}
-  {{- if dvcxClickhouse.dsn }}
+  {{- if $dvcxClickhouse.dsn }}
   DVCX_CH_DSN: {{ $dvcxClickhouse.dsn | quote }}
   {{- else if .Values.clickhouse.enabled }}
   DVCX_CH_DSN: clickhouse+native://default:{{ .Values.clickhouse.auth.password }}@{{ .Values.clickhouse.fullnameOverride }}.{{ .Release.Namespace }}.svc.cluster.local/default

--- a/charts/studio/templates/secret-studio.yaml
+++ b/charts/studio/templates/secret-studio.yaml
@@ -72,4 +72,8 @@ stringData:
 
   {{- $dvcx := .Values.global.dvcx | default dict }}
   {{- $dvcxClickhouse := $dvcx.clickHouse | default dict }}
-  DVCX_CH_DSN: {{ $dvcxClickhouse.dsn | default "" | quote }}
+  {{- if dvcxClickhouse.dsn }}
+  DVCX_CH_DSN: {{ $dvcxClickhouse.dsn | quote }}
+  {{- else if .Values.clickhouse.enabled }}
+  DVCX_CH_DSN: clickhouse+native://default:{{ .Values.clickhouse.auth.password }}@{{ .Values.clickhouse.fullnameOverride }}.{{ .Release.Namespace }}.svc.cluster.local/default
+  {{- end }}

--- a/charts/studio/templates/secret-studio.yaml
+++ b/charts/studio/templates/secret-studio.yaml
@@ -75,5 +75,9 @@ stringData:
   {{- if $dvcxClickhouse.dsn }}
   DVCX_CH_DSN: {{ $dvcxClickhouse.dsn | quote }}
   {{- else if .Values.clickhouse.enabled }}
-  DVCX_CH_DSN: clickhouse+native://default:{{ .Values.clickhouse.auth.password }}@{{ .Values.clickhouse.fullnameOverride }}.{{ .Release.Namespace }}.svc.cluster.local/default?secure=False
+  DVCX_CH_DSN: >
+    clickhouse+native://
+    {{ .Values.clickhouse.auth.username }}:{{ .Values.clickhouse.auth.password }}@
+    {{ .Values.clickhouse.fullnameOverride }}.{{ .Release.Namespace }}.svc.cluster.local/
+    default?secure=False
   {{- end }}

--- a/charts/studio/templates/secret-studio.yaml
+++ b/charts/studio/templates/secret-studio.yaml
@@ -75,5 +75,5 @@ stringData:
   {{- if $dvcxClickhouse.dsn }}
   DVCX_CH_DSN: {{ $dvcxClickhouse.dsn | quote }}
   {{- else if .Values.clickhouse.enabled }}
-  DVCX_CH_DSN: clickhouse+native://default:{{ .Values.clickhouse.auth.password }}@{{ .Values.clickhouse.fullnameOverride }}.{{ .Release.Namespace }}.svc.cluster.local/default
+  DVCX_CH_DSN: clickhouse+native://default:{{ .Values.clickhouse.auth.password }}@{{ .Values.clickhouse.fullnameOverride }}.{{ .Release.Namespace }}.svc.cluster.local/default?secure=False
   {{- end }}

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -246,7 +246,9 @@ clickhouse:
 
   # Change this before deploying
   auth:
+    # -- ClickHouse username
     username: default
+    # -- ClickHouse password
     password: clickhouse
 
 # -- PgBouncer settings group

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -249,6 +249,9 @@ clickhouse:
     # -- ClickHouse password
     password: clickhouse
 
+  shards: 1
+  replicaCount: 1
+
 # -- PgBouncer settings group
 pgBouncer:
   enabled: false

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -244,13 +244,14 @@ clickhouse:
   # -- ClickHouse name override
   fullnameOverride: studio-clickhouse
 
+  # Shards / replicas configuration
+  shards: 1
+  replicaCount: 1
+  
   # Change this before deploying
   auth:
     # -- ClickHouse password
     password: clickhouse
-
-  shards: 1
-  replicaCount: 1
 
 # -- PgBouncer settings group
 pgBouncer:

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -245,13 +245,13 @@ clickhouse:
   fullnameOverride: studio-clickhouse
 
   # Shards / replicas configuration
-  shards: 1
   replicaCount: 1
-  
+  shards: 1
+
   # Change this before deploying
   auth:
     # -- ClickHouse password
-    password: clickhouse
+    password: ""
 
 # -- PgBouncer settings group
 pgBouncer:

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -246,8 +246,6 @@ clickhouse:
 
   # Change this before deploying
   auth:
-    # -- ClickHouse username
-    username: default
     # -- ClickHouse password
     password: clickhouse
 

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -244,11 +244,6 @@ clickhouse:
   # -- ClickHouse name override
   fullnameOverride: studio-clickhouse
 
-  image:
-    registry: docker.io
-    repository: bitnami/clickhouse
-    tag: 24.4.1-debian-12-r4
-
   # Change this before deploying
   auth:
     username: default

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -251,7 +251,7 @@ clickhouse:
   # Change this before deploying
   auth:
     # -- ClickHouse password
-    password: ""
+    password: "clickhouse"
 
 # -- PgBouncer settings group
 pgBouncer:

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -238,6 +238,22 @@ postgresql:
         # -- Postgres database
         database: iterativeai
 
+clickhouse:
+  # -- ClickHouse enabled
+  enabled: false
+  # -- ClickHouse name override
+  fullnameOverride: studio-clickhouse
+
+  image:
+    registry: docker.io
+    repository: bitnami/clickhouse
+    tag: 24.4.1-debian-12-r4
+
+  # Change this before deploying
+  auth:
+    username: default
+    password: clickhouse
+
 # -- PgBouncer settings group
 pgBouncer:
   enabled: false


### PR DESCRIPTION
```yaml
clickhouse:
  enabled: true

  # Optional configuration to pull from a private registry
  image:
    registry: docker.io
    repository: bitnami/clickhouse
    tag: 24.4.1-debian-12-r4

```

> [!IMPORTANT]
> Make sure that `global.dvcx.clickHouse.dsn` is **not set**, or it will override the self-hosted ClickHouse connection string.