### PR TITLE
feat(webhook): Allow to customize webhook protocol, when exposed under custom `Host`

### DIFF
--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: studio
 description: A Helm chart for Kubernetes
 type: application
-version: 0.14.11
+version: 0.14.12
 appVersion: "v2.123.1"
 maintainers:
   - name: iterative

--- a/charts/studio/README.md
+++ b/charts/studio/README.md
@@ -1,6 +1,6 @@
 # studio
 
-![Version: 0.14.11](https://img.shields.io/badge/Version-0.14.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.123.1](https://img.shields.io/badge/AppVersion-v2.123.1-informational?style=flat-square)
+![Version: 0.14.12](https://img.shields.io/badge/Version-0.14.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.123.1](https://img.shields.io/badge/AppVersion-v2.123.1-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -82,6 +82,7 @@ A Helm chart for Kubernetes
 | global.scmProviders.gitlab.secretKey | string | `""` | GitLab OAuth App Secret Key |
 | global.scmProviders.gitlab.url | string | `""` | GitLab Enterprise Edition URL Set this if you're using the selfhosted version |
 | global.scmProviders.gitlab.webhookSecret | string | `""` | GitLab Webhook Secret |
+| global.scmProviders.tlsEnabled | bool | `false` | Enable HTTPS protocol for incoming webhooks (this works only if `global.scmProviders.webhookHost` is set; otherwise is ignored). |
 | global.scmProviders.webhookHost | string | `$global.host` value. | Custom hostname for incoming webhook (if Studio runs on a private network and you use SaaS versions of GitHub, GitLab, or Bitbucket) |
 | global.secretKey | string | `""` | Studio: Secret key for signing Webhook payloads We recommend you set this externally. If left empty, a random key will be generated. |
 | imagePullSecrets | list | `[]` | Secret containing Docker registry credentials |

--- a/charts/studio/templates/_helpers.tpl
+++ b/charts/studio/templates/_helpers.tpl
@@ -204,3 +204,11 @@ checksum/secret-studio: {{ include (print $.Template.BasePath "/secret-studio.ya
 {{- define "scheme" -}}
 http{{- if $.Values.global.ingress.tlsEnabled }}s{{- end }}
 {{- end }}
+
+{{- define "webhookScheme" -}}
+{{- if $.Values.global.scmProviders.webhookHost -}}
+http{{- if $.Values.global.scmProviders.tlsEnabled }}s{{- end }}
+{{- else -}}
+http{{- if $.Values.global.ingress.tlsEnabled }}s{{- end }}
+{{- end -}}
+{{- end }}

--- a/charts/studio/templates/configmap-studio.yaml
+++ b/charts/studio/templates/configmap-studio.yaml
@@ -26,7 +26,7 @@ data:
   BITBUCKET_API_URL: {{ .Values.global.scmProviders.bitbucket.apiUrl | quote}}
   {{- end }}
   {{- if and .Values.global.scmProviders.bitbucket.enabled $webhookHost }}
-  BITBUCKET_WEBHOOK_URL: "{{ include "scheme" . }}://{{ $webhookHost }}/webhook/bitbucket/"
+  BITBUCKET_WEBHOOK_URL: "{{ include "webhookScheme" . }}://{{ $webhookHost }}/webhook/bitbucket/"
   {{- end }}
 
   ENABLE_BLOBVAULT: "True"
@@ -75,7 +75,7 @@ data:
   GITHUB_URL: {{ .Values.global.scmProviders.github.url | quote }}
   {{- end }}
   {{- if and .Values.global.scmProviders.github.enabled $webhookHost }}
-  GITHUB_WEBHOOK_URL: "{{ include "scheme" . }}://{{ $webhookHost }}/webhook/github/"
+  GITHUB_WEBHOOK_URL: "{{ include "webhookScheme" . }}://{{ $webhookHost }}/webhook/github/"
   {{- end }}
   {{- if .Values.global.scmProviders.github.clientId }}
   GITHUB_APP_CLIENT_ID: {{ .Values.global.scmProviders.github.clientId | quote }}
@@ -94,7 +94,7 @@ data:
   GITLAB_URL: {{ .Values.global.scmProviders.gitlab.url | quote}}
   {{- end }}
   {{- if and .Values.global.scmProviders.gitlab.enabled $webhookHost }}
-  GITLAB_WEBHOOK_URL: "{{ include "scheme" . }}://{{ $webhookHost }}/webhook/gitlab/"
+  GITLAB_WEBHOOK_URL: "{{ include "webhookScheme" . }}://{{ $webhookHost }}/webhook/gitlab/"
   {{- end }}
 
   {{- if .Values.global.maxViews }}

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -124,6 +124,9 @@ global:
     # @default -- `$global.host` value.
     webhookHost: ""
 
+    # -- Enable HTTPS protocol for incoming webhooks (this works only if `global.scmProviders.webhookHost` is set; otherwise is ignored).
+    tlsEnabled: false
+
     # -- GitHub App integration with Studio.
     github:
       # -- GitHub enabled


### PR DESCRIPTION

It allows to expose webhook endpoint over HTTPS, when the Studio will run on HTTP (like internal deployment).