### PR TITLE
fix(postgresql): Pin postgres image to `14.5.0`

### DIFF
--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: studio
 description: A Helm chart for Kubernetes
 type: application
-version: 0.15.6
+version: 0.15.7
 appVersion: "v2.125.0"
 maintainers:
   - name: iterative

--- a/charts/studio/README.md
+++ b/charts/studio/README.md
@@ -1,6 +1,6 @@
 # studio
 
-![Version: 0.15.6](https://img.shields.io/badge/Version-0.15.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.125.0](https://img.shields.io/badge/AppVersion-v2.125.0-informational?style=flat-square)
+![Version: 0.15.7](https://img.shields.io/badge/Version-0.15.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.125.0](https://img.shields.io/badge/AppVersion-v2.125.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -112,6 +112,7 @@ A Helm chart for Kubernetes
 | postgresql.fullnameOverride | string | `"studio-postgresql"` | Postgres name override |
 | postgresql.global.postgresql.auth.database | string | `"iterativeai"` | Postgres database |
 | postgresql.global.postgresql.auth.postgresPassword | string | `"postgres"` | Postgres password |
+| postgresql.image.tag | string | `"14.5.0-debian-11-r35"` |  |
 | redis.auth | object | `{"enabled":false}` | Redis authentication settings |
 | redis.auth.enabled | bool | `false` | Redis authentication disabled |
 | redis.commonConfiguration | string | `"timeout 20"` | Redis common configuration to be added into the ConfigMap |

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -232,6 +232,8 @@ postgresql:
   # -- Postgres name override
   fullnameOverride: studio-postgresql
 
+  image:
+    tag: 14.5.0-debian-11-r35
   # Change this before deploying
   global:
     postgresql:


### PR DESCRIPTION
Bitnami chart does not handle the upgrade process of postgres versions.

Error from deployment:
```

2024-07-02 12:45:44.584 GMT [1] FATAL:  database files are incompatible with server
2024-07-02 12:45:44.584 GMT [1] DETAIL:  The data directory was initialized by PostgreSQL version 14, which is not compatible with this version 16.3.
```