### PR TITLE
Disable `WAIT_FOR_MIGRATIONS` on DataChain workers

### DIFF
--- a/charts/studio/templates/deployment-studio-datachain-worker.yaml
+++ b/charts/studio/templates/deployment-studio-datachain-worker.yaml
@@ -55,7 +55,7 @@ spec:
             - name: "NO_MIGRATE_DB"
               value: "1"
             - name: "WAIT_FOR_MIGRATIONS"
-              value: "1"
+              value: "0"
           envFrom:
             - configMapRef:
                 name: studio


### PR DESCRIPTION
Needed for the strangled worker.