### PR TITLE
fix secretKey description

### DIFF
--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: studio
 description: A Helm chart for Kubernetes
 type: application
-version: 0.16.26
+version: 0.16.27
 appVersion: "v2.135.1"
 maintainers:
   - name: iterative

--- a/charts/studio/README.md
+++ b/charts/studio/README.md
@@ -84,7 +84,7 @@ A Helm chart for Kubernetes
 | global.scmProviders.gitlab.webhookSecret | string | `""` | GitLab Webhook Secret |
 | global.scmProviders.tlsEnabled | bool | `false` | Enable HTTPS protocol for incoming webhooks (this works only if `global.scmProviders.webhookHost` is set; otherwise is ignored). |
 | global.scmProviders.webhookHost | string | `$global.host` value. | Custom hostname for incoming webhook (if Studio runs on a private network and you use SaaS versions of GitHub, GitLab, or Bitbucket) |
-| global.secretKey | string | `""` | Studio: Secret key for signing Webhook payloads We recommend you set this externally. If left empty, a random key will be generated. |
+| global.secretKey | string | `""` | Studio: Django SECRET_KEY to encrypt, DB, sign reaquests, etc We recommend you set and manage this externally as other secrets (e.g. DB password, user name, REDIS password, etc). If left empty, a random key will be generated. If it's not saved and lost it might be hard to recover the DB. |
 | imagePullSecrets | list | `[]` | Secret containing Docker registry credentials |
 | pgBouncer | object | `{"affinity":{},"autoscaling":{"enabled":false,"maxReplicas":5,"minReplicas":1,"targetCPUUtilizationPercentage":80},"enabled":false,"envFromSecret":"","envVars":{},"image":{"pullPolicy":"IfNotPresent","repository":"docker.io/bitnami/pgbouncer","tag":"1.22.1"},"nodeSelector":{},"podAnnotations":{},"podSecurityContext":{},"replicaCount":1,"resources":{"limits":{"memory":"1024Mi"},"requests":{"cpu":"500m","memory":"512Mi"}},"securityContext":{},"service":{"port":6432,"type":"ClusterIP"},"serviceAccountName":"","tolerations":[]}` | PgBouncer settings group |
 | pgBouncer.affinity | object | `{}` | PgBouncer pod affinity configuration |

--- a/charts/studio/README.md
+++ b/charts/studio/README.md
@@ -1,6 +1,6 @@
 # studio
 
-![Version: 0.16.26](https://img.shields.io/badge/Version-0.16.26-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.135.1](https://img.shields.io/badge/AppVersion-v2.135.1-informational?style=flat-square)
+![Version: 0.16.27](https://img.shields.io/badge/Version-0.16.27-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.135.1](https://img.shields.io/badge/AppVersion-v2.135.1-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -14,8 +14,11 @@ global:
   maxViews: "100"
   # -- Studio: Maximum number of teams
   maxTeams: "10"
-  # -- Studio: Secret key for signing Webhook payloads
-  # We recommend you set this externally. If left empty, a random key will be generated.
+  # -- Studio: Django SECRET_KEY to encrypt, DB, sign reaquests, etc
+  # We recommend you set and manage this externally as other secrets (e.g. DB
+  # password, user name, REDIS password, etc).
+  # If left empty, a random key will be generated. If it's not saved and lost
+  # it might be hard to recover the DB.
   secretKey: ""
 
   # -- (DEPRECATED) Studio: Custom CA certificate in PEM format


### PR DESCRIPTION
It was not set in one of the customer clusters as a result we lost data in DB (user credentials at the very least) when cluster was created from scratch. It was not critical (POC, dev env deployment).

Should we make it mandatory @0x2b3bfa0 @mjasion ?

Should we improve README - we now prescribe a specific value for some reason there?