### PR TITLE
Feat(istio): Add support for exposing Studio through Istio

### DIFF
--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: studio
 description: A Helm chart for Kubernetes
 type: application
-version: 0.16.37
+version: 0.17.0
 appVersion: "v2.138.3"
 maintainers:
   - name: iterative

--- a/charts/studio/README.md
+++ b/charts/studio/README.md
@@ -1,6 +1,6 @@
 # studio
 
-![Version: 0.16.37](https://img.shields.io/badge/Version-0.16.37-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.138.3](https://img.shields.io/badge/AppVersion-v2.138.3-informational?style=flat-square)
+![Version: 0.17.0](https://img.shields.io/badge/Version-0.17.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.138.3](https://img.shields.io/badge/AppVersion-v2.138.3-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -51,6 +51,10 @@ A Helm chart for Kubernetes
 | global.ingress.hostnameEnabled | bool | `true` | Configure ingress resource to match hostnames to the service |
 | global.ingress.tlsEnabled | bool | `false` | Expose studio under HTTPS protocol |
 | global.ingress.tlsSecretName | string | `"chart-example-tls"` | TLS secret name to use for HTTPS on Ingress For ALB Ingress Controller leave empty. |
+| global.istio | Experimental | `{"enabled":false,"gatewaySelector":{"istio":"ingressgateway"},"httpPort":80,"tlsPort":443}` | Managing Ingress configuration through Istio. |
+| global.istio.gatewaySelector | object | `{"istio":"ingressgateway"}` | The selector matches the ingress gateway pod labels.  If you installed Istio using Helm following the standard documentation, this would be "istio=ingressgateway". |
+| global.istio.httpPort | int | `80` | HTTP Port number where Istio Gateway will serve traffic. |
+| global.istio.tlsPort | int | `443` | HTTPS Port number where Istio Gateway will serve traffic. Require enabling `.global.ingress.tlsEnabled` |
 | global.maxTeams | string | `"10"` | Studio: Maximum number of teams |
 | global.maxViews | string | `"100"` | Studio: Maximum number of views |
 | global.postgres.databaseName | string | `"iterativeai"` | Postgres database name |

--- a/charts/studio/templates/istio-ingress.yaml
+++ b/charts/studio/templates/istio-ingress.yaml
@@ -1,0 +1,66 @@
+{{ if and .Values.global.istio.enabled (not .Values.global.ingress.enabled )}}
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: {{.Release.Name}}-studio
+spec:
+  selector: {{ toYaml .Values.global.istio.gatewaySelector | nindent 4 }}
+  servers:
+    - port:
+        number: {{.Values.global.istio.httpPort}}
+        name: http
+        protocol: HTTP
+      hosts:
+        - {{ .Values.global.host }}
+    {{- if .Values.global.ingress.tlsEnabled }}
+    - port:
+        number: {{.Values.global.istio.tlsPort}}
+        name: https
+        protocol: HTTPS
+      hosts:
+        - {{ .Values.global.host }}
+      tls:
+        mode: SIMPLE # enables HTTPS on this port
+        credentialName: {{.Values.global.ingress.tlsSecretName }}
+    {{- end }}
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: {{.Release.Name}}-studio
+  labels: {{ include "studio.labels" . | nindent 4 }}
+spec:
+  hosts:
+    - {{ .Values.global.host }}
+  gateways:
+    - {{.Release.Name}}-studio
+  http:
+    {{- if not .Values.global.blobvault.bucket }}
+    - match:
+        - uri:
+            prefix: /blobvault
+      route:
+        - destination:
+            host: {{ .Release.Name }}-blobvault
+            port:
+              number: {{ .Values.studioBlobvault.service.port | default 80 }}
+    {{- end }}
+    - match:
+        - uri:
+            prefix: /api
+        - uri:
+            prefix: /webhook
+      route:
+        - destination:
+            host: studio-backend
+            port:
+              number: {{ .Values.studioBackend.service.port }}
+    - match:
+        - uri:
+            prefix: /
+      route:
+        - destination:
+            host: studio-ui
+            port:
+              number: {{ .Values.studioUi.service.port }}
+{{- end -}}

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -102,6 +102,22 @@ global:
     # For ALB Ingress Controller leave empty.
     tlsSecretName: chart-example-tls
 
+  # -- (Experimental) Managing Ingress configuration through Istio.
+  istio:
+
+    enabled: false
+    # -- The selector matches the ingress gateway pod labels.
+    #  If you installed Istio using Helm following the standard documentation, this would be "istio=ingressgateway".
+    gatewaySelector:
+      istio: ingressgateway
+
+    # -- HTTP Port number where Istio Gateway will serve traffic.
+    httpPort: 80
+
+    # -- HTTPS Port number where Istio Gateway will serve traffic.
+    # Require enabling `.global.ingress.tlsEnabled`
+    tlsPort: 443
+
   postgres:
     # -- (DEPRECATED) Postgres database URL
     databaseUrl: ""


### PR DESCRIPTION
This PR adds support for creating Istio Gateway and VirtualServices.

The Istio support  is experimental, and by default disabled.

<details><summary>Details</summary>
<p>

```bash
helm template   .  -s templates/istio-ingress.yaml  --debug --set global.istio.enabled=true --set global.ingress.enabled=false
install.go:224: 2024-10-07 17:14:56.546755 +0200 CEST m=+0.022629626 [debug] Original chart version: ""
install.go:241: 2024-10-07 17:14:56.546808 +0200 CEST m=+0.022682626 [debug] CHART PATH: /Users/marcin/git/github.com/iterative/helm-charts/charts/studio

---
# Source: studio/templates/istio-ingress.yaml
apiVersion: networking.istio.io/v1alpha3
kind: Gateway
metadata:
  name: release-name-studio
spec:
  selector:
    istio: ingressgateway
  servers:
    - port:
        number: 80
        name: http
        protocol: HTTP
      hosts:
        - studio.example.com
---
# Source: studio/templates/istio-ingress.yaml
apiVersion: networking.istio.io/v1alpha3
kind: VirtualService
metadata:
  name: release-name-studio
  labels:
    helm.sh/chart: studio-0.16.38
    app.kubernetes.io/name: studio
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "v2.138.3"
    app.kubernetes.io/managed-by: Helm
spec:
  hosts:
    - studio.example.com
  gateways:
    - release-name-studio
  http:
    - match:
        - uri:
            prefix: /blobvault
      route:
        - destination:
            host: release-name-blobvault
            port:
              number: 80
    - match:
        - uri:
            prefix: /api
        - uri:
            prefix: /webhook
      route:
        - destination:
            host: studio-backend
            port:
              number: 8000
    - match:
        - uri:
            prefix: /
      route:
        - destination:
            host: studio-ui
            port:
              number: 3000
````

</p>
</details> 