### PR TITLE
Use CronJob for the Job template

### DIFF
--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: studio
 description: A Helm chart for Kubernetes
 type: application
-version: 0.16.97
+version: 0.16.98
 appVersion: "v2.156.0"
 maintainers:
   - name: iterative

--- a/charts/studio/README.md
+++ b/charts/studio/README.md
@@ -1,6 +1,6 @@
 # studio
 
-![Version: 0.16.97](https://img.shields.io/badge/Version-0.16.97-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.156.0](https://img.shields.io/badge/AppVersion-v2.156.0-informational?style=flat-square)
+![Version: 0.16.98](https://img.shields.io/badge/Version-0.16.98-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.156.0](https://img.shields.io/badge/AppVersion-v2.156.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/charts/studio/templates/job-studio-datachain-worker.yaml
+++ b/charts/studio/templates/job-studio-datachain-worker.yaml
@@ -27,37 +27,54 @@ spec:
           serviceAccountName: {{ include "studio-datachain-worker.serviceAccountName" . }}
           runtimeClassName: {{ (.Values.studioDatachainWorkerJobTemplate).runtimeClassName }}
           securityContext:
-            {{- toYaml (.Values.studioDatachainWorkerJobTemplate).securityContext | nindent 12 }}
-          image: "{{ (.Values.studioDatachainWorkerJobTemplate).image.repository }}:{{ (.Values.studioDatachainWorkerJobTemplate).image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ (.Values.studioDatachainWorkerJobTemplate).image.pullPolicy }}
-          args: ["/app/bin/run_celery.sh", "datachain-worker"]
-          resources:
-            {{- toYaml (.Values.studioDatachainWorkerJobTemplate).resources | nindent 12 }}
-          env:
-            - name: "NO_MIGRATE_DB"
-              value: "1"
-            - name: "WAIT_FOR_MIGRATIONS"
-              value: "0"
-            - name: "CELERY_WORKER_SINGLE_TASK_MODE"
-              value: "True"
-            - name: "CELERY_WORKER_IDLE_TIMEOUT"
-              value: {{ (.Values.studioDatachainWorkerJobTemplate).idleTimeout | quote }}
-          envFrom:
-            - configMapRef:
-                name: studio
-            - configMapRef:
-                name: {{ .Release.Name }}-datachain-worker
-            - secretRef:
-                name: studio
-            {{- if .Values.global.envFromSecret }}
-            - secretRef:
-                name: {{ .Values.global.envFromSecret }}
+            fsGroup: 103
+            fsGroupChangePolicy: "OnRootMismatch"
+            {{- with (.Values.studioDatachainWorkerJobTemplate).podSecurityContext }}
+            {{- toYaml . | nindent 8 }}
             {{- end }}
-            {{- if .Values.studioDatachainWorker.envFromSecret }}
-            - secretRef:
-                name: {{ .Values.studioDatachainWorker.envFromSecret }}
-            {{- end }}
-          volumeMounts:
+          containers:
+            - name: studio-datachain-worker
+              securityContext:
+                {{- toYaml (.Values.studioDatachainWorkerJobTemplate).securityContext | nindent 12 }}
+              image: "{{ (.Values.studioDatachainWorkerJobTemplate).image.repository }}:{{ (.Values.studioDatachainWorkerJobTemplate).image.tag | default .Chart.AppVersion }}"
+              imagePullPolicy: {{ (.Values.studioDatachainWorkerJobTemplate).image.pullPolicy }}
+              args: ["/app/bin/run_celery.sh", "datachain-worker"]
+              resources:
+                {{- toYaml (.Values.studioDatachainWorkerJobTemplate).resources | nindent 12 }}
+              env:
+                - name: "NO_MIGRATE_DB"
+                  value: "1"
+                - name: "WAIT_FOR_MIGRATIONS"
+                  value: "0"
+                - name: "CELERY_WORKER_SINGLE_TASK_MODE"
+                  value: "True"
+                - name: "CELERY_WORKER_IDLE_TIMEOUT"
+                  value: {{ (.Values.studioDatachainWorkerJobTemplate).idleTimeout | quote }}
+              envFrom:
+                - configMapRef:
+                    name: studio
+                - configMapRef:
+                    name: {{ .Release.Name }}-datachain-worker
+                - secretRef:
+                    name: studio
+                {{- if .Values.global.envFromSecret }}
+                - secretRef:
+                    name: {{ .Values.global.envFromSecret }}
+                {{- end }}
+                {{- if .Values.studioDatachainWorker.envFromSecret }}
+                - secretRef:
+                    name: {{ .Values.studioDatachainWorker.envFromSecret }}
+                {{- end }}
+              volumeMounts:
+                - name: studio-ca-certificates
+                  mountPath: /usr/local/share/ca-certificates
+                - name: tmp-ephemeral
+                  mountPath: /tmp/shared
+                {{- if (.Values.studioDatachainWorkerJobTemplate).localStorage }}
+                - name: tmp-local
+                  mountPath: /tmp/local
+                {{- end }}
+          volumes:
             - name: studio-ca-certificates
               configMap:
                 name: studio-ca-certificates

--- a/charts/studio/templates/job-studio-datachain-worker.yaml
+++ b/charts/studio/templates/job-studio-datachain-worker.yaml
@@ -1,36 +1,31 @@
 apiVersion: batch/v1
-kind: Job
+kind: CronJob
 metadata:
   name: studio-datachain-worker-template
   labels:
     {{- include "studio-datachain-worker.labels" . | nindent 4 }}
 spec:
-  suspend: true # this Job will never run; it's a template to create new Jobs
-  activeDeadlineSeconds: {{ (.Values.studioDatachainWorkerJobTemplate).activeDeadlineSeconds }}
-  ttlSecondsAfterFinished: {{ (.Values.studioDatachainWorkerJobTemplate).ttlSecondsAfterFinished }}
-  backoffLimit: {{ (.Values.studioDatachainWorkerJobTemplate).backoffLimit }}
-  template:
-    metadata:
-      annotations:
-        {{- with (.Values.studioDatachainWorkerJobTemplate).podAnnotations }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+  suspend: true # this CronJob will never run; it's just a Job template
+  schedule: "0 0 0 0 0"
+  jobTemplate:
     spec:
-      restartPolicy: Never
-      {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      serviceAccountName: {{ include "studio-datachain-worker.serviceAccountName" . }}
-      runtimeClassName: {{ (.Values.studioDatachainWorkerJobTemplate).runtimeClassName }}
-      securityContext:
-        fsGroup: 103
-        fsGroupChangePolicy: "OnRootMismatch"
-        {{- with (.Values.studioDatachainWorkerJobTemplate).podSecurityContext }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-      containers:
-        - name: studio-datachain-worker
+      activeDeadlineSeconds: {{ (.Values.studioDatachainWorkerJobTemplate).activeDeadlineSeconds }}
+      ttlSecondsAfterFinished: {{ (.Values.studioDatachainWorkerJobTemplate).ttlSecondsAfterFinished }}
+      backoffLimit: {{ (.Values.studioDatachainWorkerJobTemplate).backoffLimit }}
+      template:
+        metadata:
+          annotations:
+            {{- with (.Values.studioDatachainWorkerJobTemplate).podAnnotations }}
+            {{- toYaml . | nindent 8 }}
+            {{- end }}
+        spec:
+          restartPolicy: Never
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 8 }}
+          {{- end }}
+          serviceAccountName: {{ include "studio-datachain-worker.serviceAccountName" . }}
+          runtimeClassName: {{ (.Values.studioDatachainWorkerJobTemplate).runtimeClassName }}
           securityContext:
             {{- toYaml (.Values.studioDatachainWorkerJobTemplate).securityContext | nindent 12 }}
           image: "{{ (.Values.studioDatachainWorkerJobTemplate).image.repository }}:{{ (.Values.studioDatachainWorkerJobTemplate).image.tag | default .Chart.AppVersion }}"
@@ -47,77 +42,83 @@ spec:
               value: "True"
             - name: "CELERY_WORKER_IDLE_TIMEOUT"
               value: {{ (.Values.studioDatachainWorkerJobTemplate).idleTimeout | quote }}
+          envFrom:
+            - configMapRef:
+                name: studio
+            - configMapRef:
+                name: {{ .Release.Name }}-datachain-worker
+            - secretRef:
+                name: studio
+            {{- if .Values.global.envFromSecret }}
+            - secretRef:
+                name: {{ .Values.global.envFromSecret }}
+            {{- end }}
+            {{- if .Values.studioDatachainWorker.envFromSecret }}
+            - secretRef:
+                name: {{ .Values.studioDatachainWorker.envFromSecret }}
+            {{- end }}
           volumeMounts:
             - name: studio-ca-certificates
-              mountPath: /usr/local/share/ca-certificates
+              configMap:
+                name: studio-ca-certificates
             - name: tmp-ephemeral
-              mountPath: /tmp/shared
-            {{- if (.Values.studioDatachainWorkerJobTemplate).localStorage }}
+              {{- if eq (.Values.studioDatachainWorkerJobTemplate).ephemeralStorage.type "ephemeral" }}
+              ephemeral:
+                volumeClaimTemplate:
+                  metadata:
+                    labels:
+                      type: {{.Release.Name}}-{{ (.Values.studioDatachainWorkerJobTemplate).ephemeralStorage.persistentVolumeClaim.claimName }}
+                  spec:
+                    accessModes: [ "ReadWriteOnce" ]
+                    {{- if (.Values.studioDatachainWorkerJobTemplate).ephemeralStorage.persistentVolumeClaim.storageClass }}
+                    storageClassName: {{ (.Values.studioDatachainWorkerJobTemplate).ephemeralStorage.persistentVolumeClaim.storageClass }}
+                    {{- end }}
+                    resources:
+                      requests:
+                        storage: {{ (.Values.studioDatachainWorkerJobTemplate).ephemeralStorage.size }}
+              {{- else if eq (.Values.studioDatachainWorkerJobTemplate).ephemeralStorage.type "pvc" }}
+              persistentVolumeClaim:
+                  claimName: {{ (.Values.studioDatachainWorkerJobTemplate).ephemeralStorage.persistentVolumeClaim.claimName }}
+              {{- else if eq (.Values.studioDatachainWorkerJobTemplate).ephemeralStorage.type "pvcRWX" }}
+              persistentVolumeClaim:
+                  claimName: {{.Release.Name}}-studio-datachain-worker-ephemeral-rwx
+              {{- else if eq (.Values.studioDatachainWorkerJobTemplate).ephemeralStorage.type "emptyDir"}}
+              emptyDir:
+                sizeLimit: {{ (.Values.studioDatachainWorkerJobTemplate).ephemeralStorage.size }}
+              {{- end }}
+            {{- with (.Values.studioDatachainWorkerJobTemplate).localStorage }}
             - name: tmp-local
-              mountPath: /tmp/local
+              {{- if eq .type "ephemeral" }}
+              ephemeral:
+                volumeClaimTemplate:
+                  metadata:
+                    labels:
+                      type: {{ $.Release.Name }}-{{ .persistentVolumeClaim.claimName }}
+                  spec:
+                    accessModes: [ "ReadWriteOnce" ]
+                    {{- if .persistentVolumeClaim.storageClass }}
+                    storageClassName: {{ .persistentVolumeClaim.storageClass }}
+                    {{- end }}
+                    resources:
+                      requests:
+                        storage: {{ .size }}
+              {{- else if eq .type "pvc" }}
+              persistentVolumeClaim:
+                  claimName: {{ .persistentVolumeClaim.claimName }}
+              {{- else if eq .type "emptyDir"}}
+              emptyDir:
+                sizeLimit: {{ .size }}
+              {{- end }}
             {{- end }}
-      volumes:
-        - name: studio-ca-certificates
-          configMap:
-            name: studio-ca-certificates
-        - name: tmp-ephemeral
-          {{- if eq (.Values.studioDatachainWorkerJobTemplate).ephemeralStorage.type "ephemeral" }}
-          ephemeral:
-            volumeClaimTemplate:
-              metadata:
-                labels:
-                  type: {{.Release.Name}}-{{ (.Values.studioDatachainWorkerJobTemplate).ephemeralStorage.persistentVolumeClaim.claimName }}
-              spec:
-                accessModes: [ "ReadWriteOnce" ]
-                {{- if (.Values.studioDatachainWorkerJobTemplate).ephemeralStorage.persistentVolumeClaim.storageClass }}
-                storageClassName: {{ (.Values.studioDatachainWorkerJobTemplate).ephemeralStorage.persistentVolumeClaim.storageClass }}
-                {{- end }}
-                resources:
-                  requests:
-                    storage: {{ (.Values.studioDatachainWorkerJobTemplate).ephemeralStorage.size }}
-          {{- else if eq (.Values.studioDatachainWorkerJobTemplate).ephemeralStorage.type "pvc" }}
-          persistentVolumeClaim:
-              claimName: {{ (.Values.studioDatachainWorkerJobTemplate).ephemeralStorage.persistentVolumeClaim.claimName }}
-          {{- else if eq (.Values.studioDatachainWorkerJobTemplate).ephemeralStorage.type "pvcRWX" }}
-          persistentVolumeClaim:
-              claimName: {{.Release.Name}}-studio-datachain-worker-ephemeral-rwx
-          {{- else if eq (.Values.studioDatachainWorkerJobTemplate).ephemeralStorage.type "emptyDir"}}
-          emptyDir:
-            sizeLimit: {{ (.Values.studioDatachainWorkerJobTemplate).ephemeralStorage.size }}
+          {{- with (.Values.studioDatachainWorkerJobTemplate).nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 8 }}
           {{- end }}
-        {{- with (.Values.studioDatachainWorkerJobTemplate).localStorage }}
-        - name: tmp-local
-          {{- if eq .type "ephemeral" }}
-          ephemeral:
-            volumeClaimTemplate:
-              metadata:
-                labels:
-                  type: {{ $.Release.Name }}-{{ .persistentVolumeClaim.claimName }}
-              spec:
-                accessModes: [ "ReadWriteOnce" ]
-                {{- if .persistentVolumeClaim.storageClass }}
-                storageClassName: {{ .persistentVolumeClaim.storageClass }}
-                {{- end }}
-                resources:
-                  requests:
-                    storage: {{ .size }}
-          {{- else if eq .type "pvc" }}
-          persistentVolumeClaim:
-              claimName: {{ .persistentVolumeClaim.claimName }}
-          {{- else if eq .type "emptyDir"}}
-          emptyDir:
-            sizeLimit: {{ .size }}
+          {{- with (.Values.studioDatachainWorkerJobTemplate).affinity }}
+          affinity:
+            {{- toYaml . | nindent 8 }}
           {{- end }}
-        {{- end }}
-      {{- with (.Values.studioDatachainWorkerJobTemplate).nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with (.Values.studioDatachainWorkerJobTemplate).affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with (.Values.studioDatachainWorkerJobTemplate).tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+          {{- with (.Values.studioDatachainWorkerJobTemplate).tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 8 }}
+          {{- end }}

--- a/charts/studio/templates/job-studio-datachain-worker.yaml
+++ b/charts/studio/templates/job-studio-datachain-worker.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "studio-datachain-worker.labels" . | nindent 4 }}
 spec:
   suspend: true # this CronJob will never run; it's just a Job template
-  schedule: "0 0 0 0 0"
+  schedule: "* * * * *"
   jobTemplate:
     spec:
       activeDeadlineSeconds: {{ (.Values.studioDatachainWorkerJobTemplate).activeDeadlineSeconds }}

--- a/charts/studio/templates/job-studio-datachain-worker.yaml
+++ b/charts/studio/templates/job-studio-datachain-worker.yaml
@@ -16,13 +16,13 @@ spec:
         metadata:
           annotations:
             {{- with (.Values.studioDatachainWorkerJobTemplate).podAnnotations }}
-            {{- toYaml . | nindent 8 }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
         spec:
           restartPolicy: Never
           {{- with .Values.imagePullSecrets }}
           imagePullSecrets:
-            {{- toYaml . | nindent 8 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           serviceAccountName: {{ include "studio-datachain-worker.serviceAccountName" . }}
           runtimeClassName: {{ (.Values.studioDatachainWorkerJobTemplate).runtimeClassName }}
@@ -30,17 +30,17 @@ spec:
             fsGroup: 103
             fsGroupChangePolicy: "OnRootMismatch"
             {{- with (.Values.studioDatachainWorkerJobTemplate).podSecurityContext }}
-            {{- toYaml . | nindent 8 }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           containers:
             - name: studio-datachain-worker
               securityContext:
-                {{- toYaml (.Values.studioDatachainWorkerJobTemplate).securityContext | nindent 12 }}
+                {{- toYaml (.Values.studioDatachainWorkerJobTemplate).securityContext | nindent 16 }}
               image: "{{ (.Values.studioDatachainWorkerJobTemplate).image.repository }}:{{ (.Values.studioDatachainWorkerJobTemplate).image.tag | default .Chart.AppVersion }}"
               imagePullPolicy: {{ (.Values.studioDatachainWorkerJobTemplate).image.pullPolicy }}
               args: ["/app/bin/run_celery.sh", "datachain-worker"]
               resources:
-                {{- toYaml (.Values.studioDatachainWorkerJobTemplate).resources | nindent 12 }}
+                {{- toYaml (.Values.studioDatachainWorkerJobTemplate).resources | nindent 16 }}
               env:
                 - name: "NO_MIGRATE_DB"
                   value: "1"
@@ -129,13 +129,13 @@ spec:
             {{- end }}
           {{- with (.Values.studioDatachainWorkerJobTemplate).nodeSelector }}
           nodeSelector:
-            {{- toYaml . | nindent 8 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with (.Values.studioDatachainWorkerJobTemplate).affinity }}
           affinity:
-            {{- toYaml . | nindent 8 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with (.Values.studioDatachainWorkerJobTemplate).tolerations }}
           tolerations:
-            {{- toYaml . | nindent 8 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/studio/templates/role-datachain-worker.yaml
+++ b/charts/studio/templates/role-datachain-worker.yaml
@@ -11,6 +11,9 @@ metadata:
   {{- end }}
 rules:
   - apiGroups: ["batch"]
+    resources: ["cronjobs"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
     resources: ["jobs"]
     verbs: ["create", "get", "list", "watch"]
 {{- end }}


### PR DESCRIPTION
Helm is unable to manage updates for a Job object; using a suspended CronJob is the simplest alternative I can think of (original idea by @mjasion)

Another fix for #486, supersedes https://github.com/iterative/helm-charts/pull/549 