### PR TITLE
Separate Datachain API from Studio backend

### DIFF
--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: studio
 description: A Helm chart for Kubernetes
 type: application
-version: 0.18.15
+version: 0.18.17
 appVersion: "v2.180.3"
 maintainers:
   - name: iterative

--- a/charts/studio/README.md
+++ b/charts/studio/README.md
@@ -1,6 +1,6 @@
 # studio
 
-![Version: 0.18.15](https://img.shields.io/badge/Version-0.18.15-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.180.3](https://img.shields.io/badge/AppVersion-v2.180.3-informational?style=flat-square)
+![Version: 0.18.17](https://img.shields.io/badge/Version-0.18.17-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.180.3](https://img.shields.io/badge/AppVersion-v2.180.3-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -128,7 +128,8 @@ A Helm chart for Kubernetes
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `false` |  |
 | serviceAccount.name | string | `""` |  |
-| studioBackend | object | `{"affinity":{},"autoscaling":{"enabled":false,"maxReplicas":5,"minReplicas":1,"targetCPUUtilizationPercentage":80},"envFromSecret":"","envVars":{},"image":{"pullPolicy":"IfNotPresent","repository":"docker.iterative.ai/studio-backend"},"nodeSelector":{},"podAnnotations":{},"podSecurityContext":{},"replicaCount":1,"resources":{"limits":{"memory":"2Gi"},"requests":{"cpu":"500m","memory":"1Gi"}},"securityContext":{},"service":{"port":8000,"type":"ClusterIP"},"strategy":{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0}},"tolerations":[]}` | Studio Backend settings group |
+| studioBackend | object | `{"affinity":{},"autoscaling":{"enabled":false,"maxReplicas":5,"minReplicas":1,"targetCPUUtilizationPercentage":80},"datachainApi":{"autoscaling":{"enabled":false,"maxReplicas":5,"minReplicas":1,"targetCPUUtilizationPercentage":80},"enabled":false,"replicaCount":1,"resources":{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"256Mi"}}},"envFromSecret":"","envVars":{},"image":{"pullPolicy":"IfNotPresent","repository":"docker.iterative.ai/studio-backend"},"nodeSelector":{},"podAnnotations":{},"podSecurityContext":{},"replicaCount":1,"resources":{"limits":{"memory":"2Gi"},"requests":{"cpu":"500m","memory":"1Gi"}},"securityContext":{},"service":{"port":8000,"type":"ClusterIP"},"strategy":{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0}},"tolerations":[]}` | Studio Backend settings group |
+| studioBackend.datachainApi.replicaCount | int | `1` | Number of replicas of Datachain API backend pods |
 | studioBackend.envFromSecret | string | `""` | The name of an existing Secret that contains sensitive environment variables passed to backend pods. |
 | studioBackend.envVars | object | `{}` | Additional environment variables for backend pods |
 | studioBackend.replicaCount | int | `1` | Number of replicas of backend pods |

--- a/charts/studio/templates/_helpers.tpl
+++ b/charts/studio/templates/_helpers.tpl
@@ -79,6 +79,15 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
+{{- define "studio-datachain-api.labels" -}}
+helm.sh/chart: {{ include "studio.chart" . }}
+{{ include "studio-datachain-api.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
 {{- define "studio-ui.labels" -}}
 helm.sh/chart: {{ include "studio.chart" . }}
 {{ include "studio-ui.selectorLabels" . }}
@@ -136,6 +145,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{- define "studio-backend.selectorLabels" -}}
 app.kubernetes.io/name: studio-backend
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "studio-datachain-api.selectorLabels" -}}
+app.kubernetes.io/name: studio-datachain-api
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 

--- a/charts/studio/templates/configmap-studio-datachain-worker.yaml
+++ b/charts/studio/templates/configmap-studio-datachain-worker.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .Release.Name }}-datachain-worker
 data:
   {{- if and (or .Values.studioBackend.replicaCount .Values.studioBackend.autoscaling.enabled) (or .Values.studioDatachainWorker.replicaCount .Values.studioDatachainWorker.autoscaling.enabled) }} 
-  INTERNAL_API_URL: "http://studio-backend:{{ .Values.studioBackend.service.port }}{{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}/{{ include "studio.basePath" . }}{{- end }}/api"
+  INTERNAL_API_URL: "http://{{- if .Values.studioBackend.datachainApi.enabled }}studio-datachain-api{{- else }}studio-backend{{- end }}:{{ .Values.studioBackend.service.port }}{{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}/{{ include "studio.basePath" . }}{{- end }}/api"
   {{- end }}
   CELERY_LOG_LEVEL: "{{ .Values.studioDatachainWorker.logLevel | default "info" | lower }}"
   LOG_JSON_FORMATTER: "True"

--- a/charts/studio/templates/configmap-studio-datachain-worker.yaml
+++ b/charts/studio/templates/configmap-studio-datachain-worker.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .Release.Name }}-datachain-worker
 data:
   {{- if and (or .Values.studioBackend.replicaCount .Values.studioBackend.autoscaling.enabled) (or .Values.studioDatachainWorker.replicaCount .Values.studioDatachainWorker.autoscaling.enabled) }} 
-  INTERNAL_API_URL: "http://{{- if .Values.studioBackend.datachainApi.enabled }}studio-datachain-api{{- else }}studio-backend{{- end }}:{{ .Values.studioBackend.service.port }}{{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}/{{ include "studio.basePath" . }}{{- end }}/api"
+  INTERNAL_API_URL: "http://{{- if (default false .Values.studioBackend.datachainApi.enabled) }}studio-datachain-api{{- else }}studio-backend{{- end }}:{{ .Values.studioBackend.service.port }}{{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}/{{ include "studio.basePath" . }}{{- end }}/api"
   {{- end }}
   CELERY_LOG_LEVEL: "{{ .Values.studioDatachainWorker.logLevel | default "info" | lower }}"
   LOG_JSON_FORMATTER: "True"

--- a/charts/studio/templates/configmap-studio-datachain-worker.yaml
+++ b/charts/studio/templates/configmap-studio-datachain-worker.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .Release.Name }}-datachain-worker
 data:
   {{- if and (or .Values.studioBackend.replicaCount .Values.studioBackend.autoscaling.enabled) (or .Values.studioDatachainWorker.replicaCount .Values.studioDatachainWorker.autoscaling.enabled) }} 
-  INTERNAL_API_URL: "http://{{- if (default false .Values.studioBackend.datachainApi.enabled) }}studio-datachain-api{{- else }}studio-backend{{- end }}:{{ .Values.studioBackend.service.port }}{{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}/{{ include "studio.basePath" . }}{{- end }}/api"
+  INTERNAL_API_URL: "http://{{- if (.Values.studioBackend.datachainApi).enabled) }}studio-datachain-api{{- else }}studio-backend{{- end }}:{{ .Values.studioBackend.service.port }}{{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}/{{ include "studio.basePath" . }}{{- end }}/api"
   {{- end }}
   CELERY_LOG_LEVEL: "{{ .Values.studioDatachainWorker.logLevel | default "info" | lower }}"
   LOG_JSON_FORMATTER: "True"

--- a/charts/studio/templates/configmap-studio-datachain-worker.yaml
+++ b/charts/studio/templates/configmap-studio-datachain-worker.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .Release.Name }}-datachain-worker
 data:
   {{- if and (or .Values.studioBackend.replicaCount .Values.studioBackend.autoscaling.enabled) (or .Values.studioDatachainWorker.replicaCount .Values.studioDatachainWorker.autoscaling.enabled) }} 
-  INTERNAL_API_URL: "http://{{- if (.Values.studioBackend.datachainApi).enabled) }}studio-datachain-api{{- else }}studio-backend{{- end }}:{{ .Values.studioBackend.service.port }}{{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}/{{ include "studio.basePath" . }}{{- end }}/api"
+  INTERNAL_API_URL: "http://{{- if ((.Values.studioBackend.datachainApi).enabled) }}studio-datachain-api{{- else }}studio-backend{{- end }}:{{ .Values.studioBackend.service.port }}{{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}/{{ include "studio.basePath" . }}{{- end }}/api"
   {{- end }}
   CELERY_LOG_LEVEL: "{{ .Values.studioDatachainWorker.logLevel | default "info" | lower }}"
   LOG_JSON_FORMATTER: "True"

--- a/charts/studio/templates/deployment-studio-datachain-api.yaml
+++ b/charts/studio/templates/deployment-studio-datachain-api.yaml
@@ -1,0 +1,168 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: studio-datachain-api
+  labels:
+    {{- include "studio-datachain-api.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.studioBackend.datachainApi.enabled }}
+  replicas: 0
+  {{- else if not .Values.studioBackend.datachainApi.autoscaling.enabled }}
+  replicas: {{ .Values.studioBackend.datachainApi.replicaCount }}
+  {{- end }}
+  {{- with .Values.studioBackend.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "studio-datachain-api.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/configmap-studio-backend: {{ include (print $.Template.BasePath "/configmap-studio-backend.yaml") . | sha256sum }}
+        checksum/configmap-studio-nginx: {{ include (print $.Template.BasePath "/configmap-studio-nginx.yaml") . | sha256sum }}
+        {{- include "studio.checksum" . | indent 8 }}
+
+        {{- with .Values.studioBackend.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "studio-datachain-api.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "studio-backend.serviceAccountName" . }}
+      securityContext:
+        fsGroup: 103
+        fsGroupChangePolicy: "OnRootMismatch"
+        {{- with .Values.studioWorker.podSecurityContext }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      containers:
+        - name: studio-datachain-api
+          securityContext:
+            {{- toYaml .Values.studioBackend.securityContext | nindent 12 }}
+          image: "{{ .Values.studioBackend.image.repository }}:{{ .Values.studioBackend.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.studioBackend.image.pullPolicy }}
+          args: [ "/app/bin/run_studio.sh", "prod", "8000"]
+          ports:
+            - name: studio-http
+              containerPort: 8000
+              protocol: TCP
+          startupProbe:
+            tcpSocket:
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            failureThreshold: 30
+            successThreshold: 1
+            timeoutSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /health?format=json
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 3
+            timeoutSeconds: 60
+          livenessProbe:
+            httpGet:
+              path: /health?format=json
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 5
+            timeoutSeconds: 60
+          volumeMounts:
+            {{ if not .Values.global.blobvault.bucket }}
+            - name: blobvault
+              mountPath: /blobvault
+            {{- end }}
+            - name: studio-ca-certificates
+              mountPath: /usr/local/share/ca-certificates
+          resources:
+            {{- toYaml .Values.studioBackend.datachainApi.resources | nindent 12 }}
+          env:
+            - name: "NO_MIGRATE_DB"
+              value: "1"
+            - name: "WAIT_FOR_MIGRATIONS"
+              value: "1"
+          envFrom:
+            - configMapRef:
+                name: studio
+            - configMapRef:
+                name: studio-backend
+            - secretRef:
+                name: studio
+            {{- if .Values.global.envFromSecret }}
+            - secretRef:
+                name: {{ .Values.global.envFromSecret }}
+            {{- end }}
+            {{- if .Values.studioBackend.envFromSecret }}
+            - secretRef:
+                name: {{ .Values.studioBackend.envFromSecret }}
+            {{- end }}
+        {{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}
+        - name: nginx-sidecar
+          image: "{{ .Values.studioBlobvault.image.repository }}:{{ .Values.studioBlobvault.image.tag }}"
+          imagePullPolicy: "IfNotPresent"
+          ports:
+            - name: nginx-http
+              containerPort: 80
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+          volumeMounts:
+            - name: nginx-config
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+            - name: nginx-sidecar
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: backend-sidecar.conf
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 256Mi
+          {{- end }}
+      volumes:
+        {{ if not .Values.global.blobvault.bucket }}
+        - name: blobvault
+          persistentVolumeClaim:
+            claimName: blobvault
+        {{- end }}
+        - name: studio-ca-certificates
+          configMap:
+            name: studio-ca-certificates
+        {{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}
+        - name: nginx-config
+          configMap:
+            name: {{ .Release.Name }}-nginx
+        - name: nginx-sidecar
+          configMap:
+            name: {{ .Release.Name }}-nginx
+        {{- end }}
+      {{- with .Values.studioBackend.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.studioBackend.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.studioBackend.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/studio/templates/deployment-studio-datachain-api.yaml
+++ b/charts/studio/templates/deployment-studio-datachain-api.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "studio-datachain-api.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.studioBackend.datachainApi.enabled }}
+  {{- if not (default false .Values.studioBackend.datachainApi.enabled) }}
   replicas: 0
   {{- else if not .Values.studioBackend.datachainApi.autoscaling.enabled }}
   replicas: {{ .Values.studioBackend.datachainApi.replicaCount }}

--- a/charts/studio/templates/deployment-studio-datachain-api.yaml
+++ b/charts/studio/templates/deployment-studio-datachain-api.yaml
@@ -5,10 +5,10 @@ metadata:
   labels:
     {{- include "studio-datachain-api.labels" . | nindent 4 }}
 spec:
-  {{- if not (default false .Values.studioBackend.datachainApi.enabled) }}
+  {{- if not ((.Values.studioBackend.datachainApi).enabled) }}
   replicas: 0
-  {{- else if not .Values.studioBackend.datachainApi.autoscaling.enabled }}
-  replicas: {{ .Values.studioBackend.datachainApi.replicaCount }}
+  {{- else if not ((.Values.studioBackend.datachainApi).autoscaling.enabled) }}
+  replicas: {{ ((.Values.studioBackend.datachainApi).replicaCount) }}
   {{- end }}
   {{- with .Values.studioBackend.strategy }}
   strategy:
@@ -84,7 +84,7 @@ spec:
             - name: studio-ca-certificates
               mountPath: /usr/local/share/ca-certificates
           resources:
-            {{- toYaml .Values.studioBackend.datachainApi.resources | nindent 12 }}
+            {{- toYaml ((.Values.studioBackend.datachainApi).resources) | nindent 12 }}
           env:
             - name: "NO_MIGRATE_DB"
               value: "1"

--- a/charts/studio/templates/hpa-studio-datachain-api.yaml
+++ b/charts/studio/templates/hpa-studio-datachain-api.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.studioBackend.datachainApi.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: studio-datachain-api
+  labels:
+    {{- include "studio-datachain-api.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: studio-datachain-api
+  minReplicas: {{ .Values.studioBackend.datachainApi.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.studioBackend.datachainApi.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.studioBackend.datachainApi.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.studioBackend.datachainApi.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.studioBackend.datachainApi.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.studioBackend.datachainApi.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/studio/templates/hpa-studio-datachain-api.yaml
+++ b/charts/studio/templates/hpa-studio-datachain-api.yaml
@@ -10,23 +10,23 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: studio-datachain-api
-  minReplicas: {{ .Values.studioBackend.datachainApi.autoscaling.minReplicas }}
-  maxReplicas: {{ .Values.studioBackend.datachainApi.autoscaling.maxReplicas }}
+  minReplicas: {{ ((.Values.studioBackend.datachainApi).autoscaling.minReplicas) }}
+  maxReplicas: {{ ((.Values.studioBackend.datachainApi).autoscaling.maxReplicas) }}
   metrics:
-    {{- if .Values.studioBackend.datachainApi.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- if ((.Values.studioBackend.datachainApi).autoscaling.targetMemoryUtilizationPercentage) }}
     - type: Resource
       resource:
         name: memory
         target:
           type: Utilization
-          averageUtilization: {{ .Values.studioBackend.datachainApi.autoscaling.targetMemoryUtilizationPercentage }}
+          averageUtilization: {{ ((.Values.studioBackend.datachainApi).autoscaling.targetMemoryUtilizationPercentage) }}
     {{- end }}
-    {{- if .Values.studioBackend.datachainApi.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if ((.Values.studioBackend.datachainApi).autoscaling.targetCPUUtilizationPercentage) }}
     - type: Resource
       resource:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: {{ .Values.studioBackend.datachainApi.autoscaling.targetCPUUtilizationPercentage }}
+          averageUtilization: {{ ((.Values.studioBackend.datachainApi).autoscaling.targetCPUUtilizationPercentage) }}
     {{- end }}
 {{- end }}

--- a/charts/studio/templates/hpa-studio-datachain-api.yaml
+++ b/charts/studio/templates/hpa-studio-datachain-api.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.studioBackend.datachainApi.autoscaling.enabled }}
+{{- if ((.Values.studioBackend.datachainApi).autoscaling.enabled) }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/studio/templates/ingress-studio-api.yaml
+++ b/charts/studio/templates/ingress-studio-api.yaml
@@ -38,7 +38,7 @@ spec:
   rules:
     - http:
         paths:
-          {{- if .Values.studioBackend.datachainApi.enabled }}
+          {{- if (default false .Values.studioBackend.datachainApi.enabled) }}
           {{- $paths := list "management" "metastore" "jobs" }}
           {{- range $p := $paths }}
           {{- if and $.Values.global.basePath (not (eq $.Values.global.basePath "/")) }}

--- a/charts/studio/templates/ingress-studio-api.yaml
+++ b/charts/studio/templates/ingress-studio-api.yaml
@@ -38,14 +38,34 @@ spec:
   rules:
     - http:
         paths:
+          {{- if .Values.studioBackend.datachainApi.enabled }}
+          {{- $paths := list "management" "metastore" "jobs" }}
+          {{- range $p := $paths }}
+          {{- if and $.Values.global.basePath (not (eq $.Values.global.basePath "/")) }}
+          - path: /{{ include "studio.basePath" . }}/api/{{ $p }}
+          {{- else }}
+          - path: /api/{{ $p }}
+          {{- end }}
+            pathType: Prefix
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: studio-datachain-api
+                port:
+                  number: {{ $.Values.studioBackend.service.port }}
+              {{- else }}
+              serviceName: studio-datachain-api
+              servicePort: {{ $.Values.studioBackend.service.port }}
+              {{- end }}
+          {{- end }}
+          {{- end }}
+
           {{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}
           - path: /{{ include "studio.basePath" . }}/api
           {{- else }}
           - path: /api
           {{- end }}
-            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
-            pathType: ImplementationSpecific
-            {{- end }}
+            pathType: Prefix
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:

--- a/charts/studio/templates/ingress-studio-api.yaml
+++ b/charts/studio/templates/ingress-studio-api.yaml
@@ -38,7 +38,7 @@ spec:
   rules:
     - http:
         paths:
-          {{- if (default false .Values.studioBackend.datachainApi.enabled) }}
+          {{- if ((.Values.studioBackend.datachainApi).enabled) }}
           {{- $paths := list "management" "metastore" "jobs" }}
           {{- range $p := $paths }}
           {{- if and $.Values.global.basePath (not (eq $.Values.global.basePath "/")) }}

--- a/charts/studio/templates/ingress-studio-api.yaml
+++ b/charts/studio/templates/ingress-studio-api.yaml
@@ -65,7 +65,9 @@ spec:
           {{- else }}
           - path: /api
           {{- end }}
-            pathType: Prefix
+            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
+            pathType: ImplementationSpecific
+            {{- end }}
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:

--- a/charts/studio/templates/service-backend-datachain-api.yaml
+++ b/charts/studio/templates/service-backend-datachain-api.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: studio-datachain-api
+  labels:
+    {{- include "studio-datachain-api.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.studioBackend.service.type }}
+  ports:
+    - port: {{ .Values.studioBackend.service.port }}
+      {{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}
+      targetPort: nginx-http
+      {{- else }}
+      targetPort: studio-http
+      {{- end }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "studio-datachain-api.selectorLabels" . | nindent 4 }}

--- a/charts/studio/templates/service-datachain-api.yaml
+++ b/charts/studio/templates/service-datachain-api.yaml
@@ -1,4 +1,4 @@
-{{- if (default false .Values.studioBackend.datachainApi.enabled) }}
+{{- if ((.Values.studioBackend.datachainApi).enabled) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/studio/templates/service-datachain-api.yaml
+++ b/charts/studio/templates/service-datachain-api.yaml
@@ -1,3 +1,4 @@
+{{- if (default false .Values.studioBackend.datachainApi.enabled) }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -17,3 +18,4 @@ spec:
       name: http
   selector:
     {{- include "studio-datachain-api.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -465,6 +465,27 @@ studioBackend:
 
   affinity: {}
 
+  datachainApi:
+    enabled: false
+
+    # -- Number of replicas of Datachain API backend pods
+    replicaCount: 1
+
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+
+    autoscaling:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 5
+      targetCPUUtilizationPercentage: 80
+      # targetMemoryUtilizationPercentage: 80
+
 # -- Studio Beat settings group
 studioBeat:
   # -- Additional environment variables for beat pods


### PR DESCRIPTION
Move the following API paths to the separate deployment/pods to be able to isolate and scale them separately.

- `/api/management`
- `/api/metastore`
- `/api/jobs`