### PR TITLE
Add Helm hooks for RBAC objects

### DIFF
--- a/charts/studio/templates/clusterrole-datachain-worker-events.yaml
+++ b/charts/studio/templates/clusterrole-datachain-worker-events.yaml
@@ -7,6 +7,8 @@ metadata:
     {{- include "studio-datachain-worker.labels" . | nindent 4 }}
   {{- with .Values.studioDatachainWorker.serviceAccount.annotations }}
   annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-delete-policy: hook-failed, before-hook-creation
     {{- toYaml . | nindent 4 }}
   {{- end }}
 rules:

--- a/charts/studio/templates/clusterrolebinding-datachain-worker-events.yaml
+++ b/charts/studio/templates/clusterrolebinding-datachain-worker-events.yaml
@@ -7,6 +7,8 @@ metadata:
     {{- include "studio-datachain-worker.labels" . | nindent 4 }}
   {{- with .Values.studioDatachainWorker.serviceAccount.annotations }}
   annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-delete-policy: hook-failed, before-hook-creation
     {{- toYaml . | nindent 4 }}
   {{- end }}
 subjects:

--- a/charts/studio/templates/role-datachain-worker.yaml
+++ b/charts/studio/templates/role-datachain-worker.yaml
@@ -7,6 +7,8 @@ metadata:
     {{- include "studio-datachain-worker.labels" . | nindent 4 }}
   {{- with .Values.studioDatachainWorker.serviceAccount.annotations }}
   annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-delete-policy: hook-failed, before-hook-creation
     {{- toYaml . | nindent 4 }}
   {{- end }}
 rules:

--- a/charts/studio/templates/rolebinding-datachain-worker.yaml
+++ b/charts/studio/templates/rolebinding-datachain-worker.yaml
@@ -7,6 +7,8 @@ metadata:
     {{- include "studio-datachain-worker.labels" . | nindent 4 }}
   {{- with .Values.studioDatachainWorker.serviceAccount.annotations }}
   annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-delete-policy: hook-failed, before-hook-creation
     {{- toYaml . | nindent 4 }}
   {{- end }}
 subjects:

--- a/charts/studio/templates/serviceaccount-backend.yaml
+++ b/charts/studio/templates/serviceaccount-backend.yaml
@@ -7,6 +7,8 @@ metadata:
     {{- include "studio-backend.labels" . | nindent 4 }}
   {{- with .Values.studioBackend.serviceAccount.annotations }}
   annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-delete-policy: hook-failed, before-hook-creation
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/studio/templates/serviceaccount-datachain-worker.yaml
+++ b/charts/studio/templates/serviceaccount-datachain-worker.yaml
@@ -7,6 +7,8 @@ metadata:
     {{- include "studio-datachain-worker.labels" . | nindent 4 }}
   {{- with .Values.studioDatachainWorker.serviceAccount.annotations }}
   annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-delete-policy: hook-failed, before-hook-creation
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/studio/templates/serviceaccount-worker.yaml
+++ b/charts/studio/templates/serviceaccount-worker.yaml
@@ -7,6 +7,8 @@ metadata:
     {{- include "studio-worker.labels" . | nindent 4 }}
   {{- with .Values.studioWorker.serviceAccount.annotations }}
   annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-delete-policy: hook-failed, before-hook-creation
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/studio/templates/serviceaccount.yaml
+++ b/charts/studio/templates/serviceaccount.yaml
@@ -7,6 +7,8 @@ metadata:
     {{- include "studio.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-delete-policy: hook-failed, before-hook-creation
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Prevents `AlreadyExists` errors during upgrade.