### PR TITLE
Fix local development in k8s

### DIFF
--- a/skaffold/base/kustomization.yaml
+++ b/skaffold/base/kustomization.yaml
@@ -3,10 +3,3 @@ kind: Kustomization
 
 resources:
   - https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
-
-patches:
-  - patch: |-
-      - op: remove
-        path: /spec/template/spec/nodeSelector/ingress-ready
-    target:
-      kind: Deployment


### PR DESCRIPTION
Patch is not needed, since it was removed here: https://github.com/kubernetes/ingress-nginx/commit/9dc73d17c76e2289408ebff2f3446b8b13c3e72e