### PR TITLE
Save raw events to Vector

### DIFF
--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -1269,6 +1269,7 @@ vector-aggregator:
             "object_name": .items.involvedObject.name,
             "timestamp": .items.lastTimestamp,
             "message": .items.message,
+            "raw": .
           }
       kubernetes_events_deduped:
         type: dedupe


### PR DESCRIPTION
Will consume more storage and resouces, but worth keeping for investigation.