### PR TITLE
Use docker.io/bitnamilegacy instead of docker.io/bitnami

### DIFF
--- a/.github/workflows/helm-lint-and-install.yaml
+++ b/.github/workflows/helm-lint-and-install.yaml
@@ -45,7 +45,7 @@ jobs:
           changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
           if [[ -n "$changed" ]]; then
             echo "Found changed charts: $changed"
-            echo "changed=true" >> "$GITHUB_OUTPUT"
+#            echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run chart-testing (lint)

--- a/.github/workflows/helm-lint-and-install.yaml
+++ b/.github/workflows/helm-lint-and-install.yaml
@@ -45,7 +45,7 @@ jobs:
           changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
           if [[ -n "$changed" ]]; then
             echo "Found changed charts: $changed"
-#            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run chart-testing (lint)

--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: studio
 description: A Helm chart for Kubernetes
 type: application
-version: 0.18.110
+version: 0.18.111
 appVersion: "v2.210.0"
 maintainers:
   - name: iterative

--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: studio
 description: A Helm chart for Kubernetes
 type: application
-version: 0.18.109
+version: 0.18.110
 appVersion: "v2.210.0"
 maintainers:
   - name: iterative

--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: studio
 description: A Helm chart for Kubernetes
 type: application
-version: 0.18.111
+version: 0.18.110
 appVersion: "v2.210.0"
 maintainers:
   - name: iterative

--- a/charts/studio/README.md
+++ b/charts/studio/README.md
@@ -117,8 +117,7 @@ A Helm chart for Kubernetes
 | postgresql.fullnameOverride | string | `"studio-postgresql"` | Postgres name override |
 | postgresql.global.postgresql.auth.database | string | `"iterativeai"` | Postgres database |
 | postgresql.global.postgresql.auth.postgresPassword | string | `"postgres"` | Postgres password |
-| postgresql.image.repository | string | `"docker.io/bitnamilegacy/postgresql"` |  |
-| postgresql.image.tag | string | `"14.5.0-debian-11-r35"` |  |
+| postgresql.image | object | `{"registry":"docker.io","repository":"bitnamilegacy/postgresql","tag":"14.5.0-debian-11-r35"}` | Postgres image configuration |
 | redis.auth | object | `{"enabled":false}` | Redis authentication settings |
 | redis.auth.enabled | bool | `false` | Redis authentication disabled |
 | redis.commonConfiguration | string | `"timeout 20"` | Redis common configuration to be added into the ConfigMap |

--- a/charts/studio/README.md
+++ b/charts/studio/README.md
@@ -117,7 +117,7 @@ A Helm chart for Kubernetes
 | postgresql.fullnameOverride | string | `"studio-postgresql"` | Postgres name override |
 | postgresql.global.postgresql.auth.database | string | `"iterativeai"` | Postgres database |
 | postgresql.global.postgresql.auth.postgresPassword | string | `"postgres"` | Postgres password |
-| postgresql.image | object | `{"registry":"docker.io","repository":"bitnamilegacy/postgresql","tag":"14.5.0-debian-11-r35"}` | Postgres image configuration |
+| postgresql.image | object | `{"repository":"docker.io/bitnamilegacy/postgresql","tag":"14.5.0-debian-11-r35"}` | Postgres image configuration |
 | redis.auth | object | `{"enabled":false}` | Redis authentication settings |
 | redis.auth.enabled | bool | `false` | Redis authentication disabled |
 | redis.commonConfiguration | string | `"timeout 20"` | Redis common configuration to be added into the ConfigMap |

--- a/charts/studio/README.md
+++ b/charts/studio/README.md
@@ -27,7 +27,7 @@ A Helm chart for Kubernetes
 | clickhouse.auth.password | string | `"clickhouse"` | ClickHouse password |
 | clickhouse.enabled | bool | `false` | ClickHouse enabled |
 | clickhouse.fullnameOverride | string | `"studio-clickhouse"` | ClickHouse name override |
-| clickhouse.image | object | `{"repository":"docker.io/bitnamilegacy/clickhouse"}` | ClickHouse image configuration |
+| clickhouse.image | object | `{"repository":"bitnamilegacy/clickhouse"}` | ClickHouse image configuration |
 | clickhouse.replicaCount | int | `1` |  |
 | clickhouse.shards | int | `1` |  |
 | global.basePath | string | `""` | Studio: Base path (prefix) |
@@ -91,7 +91,7 @@ A Helm chart for Kubernetes
 | global.security | object | `{"allowInsecureImages":true}` | Security settings for Bitnami Legacy images |
 | global.security.allowInsecureImages | bool | `true` | Allow insecure images from bitnamilegacy repository |
 | imagePullSecrets | list | `[]` | Secret containing Docker registry credentials |
-| pgBouncer | object | `{"affinity":{},"autoscaling":{"enabled":false,"maxReplicas":5,"minReplicas":1,"targetCPUUtilizationPercentage":80},"enabled":false,"envFromSecret":"","envVars":{},"image":{"pullPolicy":"IfNotPresent","repository":"docker.io/bitnamilegacy/pgbouncer","tag":"1.24.1"},"nodeSelector":{},"podAnnotations":{},"podSecurityContext":{},"replicaCount":1,"resources":{"limits":{"memory":"1024Mi"},"requests":{"cpu":"500m","memory":"512Mi"}},"securityContext":{},"service":{"port":6432,"type":"ClusterIP"},"serviceAccountName":"","tolerations":[]}` | PgBouncer settings group |
+| pgBouncer | object | `{"affinity":{},"autoscaling":{"enabled":false,"maxReplicas":5,"minReplicas":1,"targetCPUUtilizationPercentage":80},"enabled":false,"envFromSecret":"","envVars":{},"image":{"pullPolicy":"IfNotPresent","repository":"bitnamilegacy/pgbouncer","tag":"1.24.1"},"nodeSelector":{},"podAnnotations":{},"podSecurityContext":{},"replicaCount":1,"resources":{"limits":{"memory":"1024Mi"},"requests":{"cpu":"500m","memory":"512Mi"}},"securityContext":{},"service":{"port":6432,"type":"ClusterIP"},"serviceAccountName":"","tolerations":[]}` | PgBouncer settings group |
 | pgBouncer.affinity | object | `{}` | PgBouncer pod affinity configuration |
 | pgBouncer.autoscaling | object | `{"enabled":false,"maxReplicas":5,"minReplicas":1,"targetCPUUtilizationPercentage":80}` | PgBouncer autoscaling configuration |
 | pgBouncer.autoscaling.enabled | bool | `false` | PgBouncer autoscaling enabled flag |
@@ -100,9 +100,9 @@ A Helm chart for Kubernetes
 | pgBouncer.autoscaling.targetCPUUtilizationPercentage | int | `80` | PgBouncer autoscaling target CPU utilization percentage |
 | pgBouncer.envFromSecret | string | `""` | The name of an existing Secret that contains sensitive environment variables. |
 | pgBouncer.envVars | object | `{}` | Additional environment variables for PgBouncer pods |
-| pgBouncer.image | object | `{"pullPolicy":"IfNotPresent","repository":"docker.io/bitnamilegacy/pgbouncer","tag":"1.24.1"}` | PgBouncer image settings |
+| pgBouncer.image | object | `{"pullPolicy":"IfNotPresent","repository":"bitnamilegacy/pgbouncer","tag":"1.24.1"}` | PgBouncer image settings |
 | pgBouncer.image.pullPolicy | string | `"IfNotPresent"` | PgBouncer image pull policy |
-| pgBouncer.image.repository | string | `"docker.io/bitnamilegacy/pgbouncer"` | PgBouncer image repository |
+| pgBouncer.image.repository | string | `"bitnamilegacy/pgbouncer"` | PgBouncer image repository |
 | pgBouncer.image.tag | string | `"1.24.1"` | PgBouncer image tag |
 | pgBouncer.nodeSelector | object | `{}` | PgBouncer pod node selector configuration |
 | pgBouncer.podAnnotations | object | `{}` | Additional PgBouncer pod annotations |
@@ -117,13 +117,13 @@ A Helm chart for Kubernetes
 | postgresql.fullnameOverride | string | `"studio-postgresql"` | Postgres name override |
 | postgresql.global.postgresql.auth.database | string | `"iterativeai"` | Postgres database |
 | postgresql.global.postgresql.auth.postgresPassword | string | `"postgres"` | Postgres password |
-| postgresql.image | object | `{"repository":"docker.io/bitnamilegacy/postgresql","tag":"14.5.0-debian-11-r35"}` | Postgres image configuration |
+| postgresql.image | object | `{"repository":"bitnamilegacy/postgresql","tag":"14.5.0-debian-11-r35"}` | Postgres image configuration |
 | redis.auth | object | `{"enabled":false}` | Redis authentication settings |
 | redis.auth.enabled | bool | `false` | Redis authentication disabled |
 | redis.commonConfiguration | string | `"timeout 20"` | Redis common configuration to be added into the ConfigMap |
 | redis.enabled | bool | `true` | Redis enabled |
 | redis.fullnameOverride | string | `"studio-redis"` | Redis name override |
-| redis.image | object | `{"repository":"docker.io/bitnamilegacy/redis"}` | Redis image configuration |
+| redis.image | object | `{"repository":"bitnamilegacy/redis"}` | Redis image configuration |
 | redis.master | object | `{"persistence":{"enabled":false},"resources":{"limits":{"cpu":"1000m","memory":"2Gi"},"requests":{"cpu":"200m","memory":"512Mi"}}}` | Redis master configuration |
 | redis.master.persistence | object | `{"enabled":false}` | Redis master persistence configuration |
 | redis.master.persistence.enabled | bool | `false` | Redis master persistence is disabled |

--- a/charts/studio/README.md
+++ b/charts/studio/README.md
@@ -1,6 +1,6 @@
 # studio
 
-![Version: 0.18.109](https://img.shields.io/badge/Version-0.18.109-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.210.0](https://img.shields.io/badge/AppVersion-v2.210.0-informational?style=flat-square)
+![Version: 0.18.110](https://img.shields.io/badge/Version-0.18.110-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.210.0](https://img.shields.io/badge/AppVersion-v2.210.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -27,6 +27,7 @@ A Helm chart for Kubernetes
 | clickhouse.auth.password | string | `"clickhouse"` | ClickHouse password |
 | clickhouse.enabled | bool | `false` | ClickHouse enabled |
 | clickhouse.fullnameOverride | string | `"studio-clickhouse"` | ClickHouse name override |
+| clickhouse.image | object | `{"repository":"docker.io/bitnamilegacy/clickhouse"}` | ClickHouse image configuration |
 | clickhouse.replicaCount | int | `1` |  |
 | clickhouse.shards | int | `1` |  |
 | global.basePath | string | `""` | Studio: Base path (prefix) |
@@ -87,8 +88,10 @@ A Helm chart for Kubernetes
 | global.scmProviders.tlsEnabled | bool | `false` | Enable HTTPS protocol for incoming webhooks (this works only if `global.scmProviders.webhookHost` is set; otherwise is ignored). |
 | global.scmProviders.webhookHost | string | `$global.host` value. | Custom hostname for incoming webhook (if Studio runs on a private network and you use SaaS versions of GitHub, GitLab, or Bitbucket) |
 | global.secretKey | string | `""` | Studio: Django SECRET_KEY to encrypt, DB, sign reaquests, etc We recommend you set and manage this externally as other secrets (e.g. DB password, user name, REDIS password, etc). If left empty, a random key will be generated. If it's not saved and lost it might be hard to recover the DB. |
+| global.security | object | `{"allowInsecureImages":true}` | Security settings for Bitnami Legacy images |
+| global.security.allowInsecureImages | bool | `true` | Allow insecure images from bitnamilegacy repository |
 | imagePullSecrets | list | `[]` | Secret containing Docker registry credentials |
-| pgBouncer | object | `{"affinity":{},"autoscaling":{"enabled":false,"maxReplicas":5,"minReplicas":1,"targetCPUUtilizationPercentage":80},"enabled":false,"envFromSecret":"","envVars":{},"image":{"pullPolicy":"IfNotPresent","repository":"docker.io/bitnami/pgbouncer","tag":"1.24.1"},"nodeSelector":{},"podAnnotations":{},"podSecurityContext":{},"replicaCount":1,"resources":{"limits":{"memory":"1024Mi"},"requests":{"cpu":"500m","memory":"512Mi"}},"securityContext":{},"service":{"port":6432,"type":"ClusterIP"},"serviceAccountName":"","tolerations":[]}` | PgBouncer settings group |
+| pgBouncer | object | `{"affinity":{},"autoscaling":{"enabled":false,"maxReplicas":5,"minReplicas":1,"targetCPUUtilizationPercentage":80},"enabled":false,"envFromSecret":"","envVars":{},"image":{"pullPolicy":"IfNotPresent","repository":"docker.io/bitnamilegacy/pgbouncer","tag":"1.24.1"},"nodeSelector":{},"podAnnotations":{},"podSecurityContext":{},"replicaCount":1,"resources":{"limits":{"memory":"1024Mi"},"requests":{"cpu":"500m","memory":"512Mi"}},"securityContext":{},"service":{"port":6432,"type":"ClusterIP"},"serviceAccountName":"","tolerations":[]}` | PgBouncer settings group |
 | pgBouncer.affinity | object | `{}` | PgBouncer pod affinity configuration |
 | pgBouncer.autoscaling | object | `{"enabled":false,"maxReplicas":5,"minReplicas":1,"targetCPUUtilizationPercentage":80}` | PgBouncer autoscaling configuration |
 | pgBouncer.autoscaling.enabled | bool | `false` | PgBouncer autoscaling enabled flag |
@@ -97,9 +100,9 @@ A Helm chart for Kubernetes
 | pgBouncer.autoscaling.targetCPUUtilizationPercentage | int | `80` | PgBouncer autoscaling target CPU utilization percentage |
 | pgBouncer.envFromSecret | string | `""` | The name of an existing Secret that contains sensitive environment variables. |
 | pgBouncer.envVars | object | `{}` | Additional environment variables for PgBouncer pods |
-| pgBouncer.image | object | `{"pullPolicy":"IfNotPresent","repository":"docker.io/bitnami/pgbouncer","tag":"1.24.1"}` | PgBouncer image settings |
+| pgBouncer.image | object | `{"pullPolicy":"IfNotPresent","repository":"docker.io/bitnamilegacy/pgbouncer","tag":"1.24.1"}` | PgBouncer image settings |
 | pgBouncer.image.pullPolicy | string | `"IfNotPresent"` | PgBouncer image pull policy |
-| pgBouncer.image.repository | string | `"docker.io/bitnami/pgbouncer"` | PgBouncer image repository |
+| pgBouncer.image.repository | string | `"docker.io/bitnamilegacy/pgbouncer"` | PgBouncer image repository |
 | pgBouncer.image.tag | string | `"1.24.1"` | PgBouncer image tag |
 | pgBouncer.nodeSelector | object | `{}` | PgBouncer pod node selector configuration |
 | pgBouncer.podAnnotations | object | `{}` | Additional PgBouncer pod annotations |
@@ -114,12 +117,14 @@ A Helm chart for Kubernetes
 | postgresql.fullnameOverride | string | `"studio-postgresql"` | Postgres name override |
 | postgresql.global.postgresql.auth.database | string | `"iterativeai"` | Postgres database |
 | postgresql.global.postgresql.auth.postgresPassword | string | `"postgres"` | Postgres password |
+| postgresql.image.repository | string | `"docker.io/bitnamilegacy/postgresql"` |  |
 | postgresql.image.tag | string | `"14.5.0-debian-11-r35"` |  |
 | redis.auth | object | `{"enabled":false}` | Redis authentication settings |
 | redis.auth.enabled | bool | `false` | Redis authentication disabled |
 | redis.commonConfiguration | string | `"timeout 20"` | Redis common configuration to be added into the ConfigMap |
 | redis.enabled | bool | `true` | Redis enabled |
 | redis.fullnameOverride | string | `"studio-redis"` | Redis name override |
+| redis.image | object | `{"repository":"docker.io/bitnamilegacy/redis"}` | Redis image configuration |
 | redis.master | object | `{"persistence":{"enabled":false},"resources":{"limits":{"cpu":"1000m","memory":"2Gi"},"requests":{"cpu":"200m","memory":"512Mi"}}}` | Redis master configuration |
 | redis.master.persistence | object | `{"enabled":false}` | Redis master persistence configuration |
 | redis.master.persistence.enabled | bool | `false` | Redis master persistence is disabled |

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -200,7 +200,7 @@ redis:
 
   # -- Redis image configuration
   image:
-    repository: docker.io/bitnamilegacy/redis
+    repository: bitnamilegacy/redis
 
   # -- Redis master configuration
   master:
@@ -246,7 +246,7 @@ postgresql:
 
   # -- Postgres image configuration
   image:
-    repository: docker.io/bitnamilegacy/postgresql
+    repository: bitnamilegacy/postgresql
     tag: 14.5.0-debian-11-r35
 
   # Change this before deploying
@@ -266,7 +266,7 @@ clickhouse:
 
   # -- ClickHouse image configuration
   image:
-    repository: docker.io/bitnamilegacy/clickhouse
+    repository: bitnamilegacy/clickhouse
 
   # Shards / replicas configuration
   replicaCount: 1
@@ -284,7 +284,7 @@ pgBouncer:
   # -- PgBouncer image settings
   image:
     # -- PgBouncer image repository
-    repository: docker.io/bitnamilegacy/pgbouncer
+    repository: bitnamilegacy/pgbouncer
     # -- PgBouncer image pull policy
     pullPolicy: IfNotPresent
     # -- PgBouncer image tag

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -6,6 +6,11 @@
 imagePullSecrets: []
 
 global:
+  # -- Security settings for Bitnami Legacy images
+  security:
+    # -- Allow insecure images from bitnamilegacy repository
+    allowInsecureImages: true
+
   # -- Studio: Hostname for accessing Studio (no http(s) scheme)
   host: "studio.example.com"
   # -- Studio: Base path (prefix)
@@ -193,6 +198,10 @@ redis:
   # -- Redis name override
   fullnameOverride: studio-redis
 
+  # -- Redis image configuration
+  image:
+    repository: docker.io/bitnamilegacy/redis
+
   # -- Redis master configuration
   master:
     ## Redis&reg; master resource requests and limits
@@ -236,6 +245,7 @@ postgresql:
   fullnameOverride: studio-postgresql
 
   image:
+    repository: docker.io/bitnamilegacy/postgresql
     tag: 14.5.0-debian-11-r35
   # Change this before deploying
   global:
@@ -251,6 +261,10 @@ clickhouse:
   enabled: false
   # -- ClickHouse name override
   fullnameOverride: studio-clickhouse
+
+  # -- ClickHouse image configuration
+  image:
+    repository: docker.io/bitnamilegacy/clickhouse
 
   # Shards / replicas configuration
   replicaCount: 1
@@ -268,7 +282,7 @@ pgBouncer:
   # -- PgBouncer image settings
   image:
     # -- PgBouncer image repository
-    repository: docker.io/bitnami/pgbouncer
+    repository: docker.io/bitnamilegacy/pgbouncer
     # -- PgBouncer image pull policy
     pullPolicy: IfNotPresent
     # -- PgBouncer image tag

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -244,9 +244,12 @@ postgresql:
   # -- Postgres name override
   fullnameOverride: studio-postgresql
 
+  # -- Postgres image configuration
   image:
-    repository: docker.io/bitnamilegacy/postgresql
+    registry: docker.io
+    repository: bitnamilegacy/postgresql
     tag: 14.5.0-debian-11-r35
+
   # Change this before deploying
   global:
     postgresql:

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -246,8 +246,7 @@ postgresql:
 
   # -- Postgres image configuration
   image:
-    registry: docker.io
-    repository: bitnamilegacy/postgresql
+    repository: docker.io/bitnamilegacy/postgresql
     tag: 14.5.0-debian-11-r35
 
   # Change this before deploying


### PR DESCRIPTION
Proper fix is needed ASAP. For example, we can put redis, postgresql and clickhouse images in our docker registry.

See reason here: https://github.com/bitnami/charts/issues/35164

And this thread in Slack: https://iterativeai.slack.com/archives/C04A9RWEZBN/p1758157920606229

**NOTE**: I don't like this **AT ALL**, but I can not find another quick fix for this.

```yaml
global:
  # -- Security settings for Bitnami Legacy images
  security:
    # -- Allow insecure images from bitnamilegacy repository
    allowInsecureImages: true
```