### PR TITLE
studio: support mounting CA bundles from an existing Secret

### DIFF
--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: studio
 description: A Helm chart for Kubernetes
 type: application
-version: 0.19.74
+version: 0.19.75
 appVersion: "v2.241.2"
 maintainers:
   - name: iterative

--- a/charts/studio/README.md
+++ b/charts/studio/README.md
@@ -1,6 +1,6 @@
 # studio
 
-![Version: 0.19.74](https://img.shields.io/badge/Version-0.19.74-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.241.2](https://img.shields.io/badge/AppVersion-v2.241.2-informational?style=flat-square)
+![Version: 0.19.75](https://img.shields.io/badge/Version-0.19.75-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.241.2](https://img.shields.io/badge/AppVersion-v2.241.2-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -45,6 +45,7 @@ A Helm chart for Kubernetes
 | global.celery.resultBackend | string | `""` | Celery result URL |
 | global.customCaCert | DEPRECATED | `""` | Studio: Custom CA certificate in PEM format Deprecated in favor of `customCaCerts` customCaCert: |-   -----BEGIN CERTIFICATE-----   ....   -----END CERTIFICATE-----  |
 | global.customCaCerts | list | `[]` | Studio: Custom CA certificate in PEM format customCaCerts: - |-     -----BEGIN CERTIFICATE-----     ....     -----END CERTIFICATE-----  |
+| global.customCaCertsFromSecret | string | `""` | Studio: Name of an existing Secret in the release namespace whose data keys will be projected alongside the chart-managed `studio-ca-certificates` ConfigMap under `/usr/local/share/ca-certificates/`. Intended for CA bundles managed out-of-band (e.g. via External Secrets) so they can be rotated without a chart bump. Secret keys should end in `.crt` and must not collide with the keys generated from `customCaCert`/`customCaCerts` (`self_signed_ca*.crt`). Pods are not auto-rolled when the Secret's contents change — use a controller such as stakater/reloader if you need rotation to take effect without a manual restart. |
 | global.datachain | object | `{}` | Studio: Settings related to DataChain |
 | global.envFromSecret | string | `""` | Studio: The name of an existing Secret that contains sensitive environment variables passed to all Studio pods. |
 | global.envVars | object | `{}` | Studio: Additional environment variables for all pods |

--- a/charts/studio/templates/deployment-studio-backend.yaml
+++ b/charts/studio/templates/deployment-studio-backend.yaml
@@ -180,8 +180,17 @@ spec:
             claimName: blobvault
         {{- end }}
         - name: studio-ca-certificates
+          {{- if .Values.global.customCaCertsFromSecret }}
+          projected:
+            sources:
+              - configMap:
+                  name: studio-ca-certificates
+              - secret:
+                  name: {{ .Values.global.customCaCertsFromSecret }}
+          {{- else }}
           configMap:
             name: studio-ca-certificates
+          {{- end }}
         {{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}
         - name: nginx-config
           configMap:

--- a/charts/studio/templates/deployment-studio-beat.yaml
+++ b/charts/studio/templates/deployment-studio-beat.yaml
@@ -75,8 +75,17 @@ spec:
               mountPath: /usr/local/share/ca-certificates
       volumes:
         - name: studio-ca-certificates
+          {{- if .Values.global.customCaCertsFromSecret }}
+          projected:
+            sources:
+              - configMap:
+                  name: studio-ca-certificates
+              - secret:
+                  name: {{ .Values.global.customCaCertsFromSecret }}
+          {{- else }}
           configMap:
             name: studio-ca-certificates
+          {{- end }}
       {{- with .Values.studioBeat.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/studio/templates/deployment-studio-datachain-api.yaml
+++ b/charts/studio/templates/deployment-studio-datachain-api.yaml
@@ -148,8 +148,17 @@ spec:
             claimName: blobvault
         {{- end }}
         - name: studio-ca-certificates
+          {{- if .Values.global.customCaCertsFromSecret }}
+          projected:
+            sources:
+              - configMap:
+                  name: studio-ca-certificates
+              - secret:
+                  name: {{ .Values.global.customCaCertsFromSecret }}
+          {{- else }}
           configMap:
             name: studio-ca-certificates
+          {{- end }}
         {{- if and .Values.global.basePath (not (eq .Values.global.basePath "/")) }}
         - name: nginx-config
           configMap:

--- a/charts/studio/templates/deployment-studio-datachain-worker.yaml
+++ b/charts/studio/templates/deployment-studio-datachain-worker.yaml
@@ -90,8 +90,17 @@ spec:
               mountPath: /usr/local/share/ca-certificates
       volumes:
         - name: studio-ca-certificates
+          {{- if .Values.global.customCaCertsFromSecret }}
+          projected:
+            sources:
+              - configMap:
+                  name: studio-ca-certificates
+              - secret:
+                  name: {{ .Values.global.customCaCertsFromSecret }}
+          {{- else }}
           configMap:
             name: studio-ca-certificates
+          {{- end }}
       {{- with .Values.studioDatachainWorker.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/studio/templates/deployment-studio-worker.yaml
+++ b/charts/studio/templates/deployment-studio-worker.yaml
@@ -83,8 +83,17 @@ spec:
             claimName: blobvault
         {{- end }}
         - name: studio-ca-certificates
+          {{- if .Values.global.customCaCertsFromSecret }}
+          projected:
+            sources:
+              - configMap:
+                  name: studio-ca-certificates
+              - secret:
+                  name: {{ .Values.global.customCaCertsFromSecret }}
+          {{- else }}
           configMap:
             name: studio-ca-certificates
+          {{- end }}
         - name: tmp-ephemeral
           {{- if eq .Values.studioWorker.ephemeralStorage.type "ephemeral" }}
           ephemeral:

--- a/charts/studio/templates/job-studio-datachain-worker.yaml
+++ b/charts/studio/templates/job-studio-datachain-worker.yaml
@@ -94,8 +94,17 @@ spec:
                 {{- end }}
           volumes:
             - name: studio-ca-certificates
+              {{- if .Values.global.customCaCertsFromSecret }}
+              projected:
+                sources:
+                  - configMap:
+                      name: studio-ca-certificates
+                  - secret:
+                      name: {{ .Values.global.customCaCertsFromSecret }}
+              {{- else }}
               configMap:
                 name: studio-ca-certificates
+              {{- end }}
             - name: tmp-ephemeral
               {{- if eq (.Values.studioDatachainWorkerJobTemplate).ephemeralStorage.type "ephemeral" }}
               ephemeral:

--- a/charts/studio/values.yaml
+++ b/charts/studio/values.yaml
@@ -44,6 +44,16 @@ global:
   #
   customCaCerts: []
 
+  # -- Studio: Name of an existing Secret in the release namespace whose data keys
+  # will be projected alongside the chart-managed `studio-ca-certificates` ConfigMap
+  # under `/usr/local/share/ca-certificates/`. Intended for CA bundles managed
+  # out-of-band (e.g. via External Secrets) so they can be rotated without a chart
+  # bump. Secret keys should end in `.crt` and must not collide with the keys
+  # generated from `customCaCert`/`customCaCerts` (`self_signed_ca*.crt`). Pods are
+  # not auto-rolled when the Secret's contents change — use a controller such as
+  # stakater/reloader if you need rotation to take effect without a manual restart.
+  customCaCertsFromSecret: ""
+
 
   # -- Studio: Additional environment variables for all pods
   envVars: {}


### PR DESCRIPTION
## Summary

Adds `global.customCaCertsFromSecret` to the `studio` chart, accepting the name of a Secret in the release namespace whose data keys are projected alongside the chart-managed `studio-ca-certificates` ConfigMap under `/usr/local/share/ca-certificates/`.

The motivating use case: pull the AWS RDS CA bundle from `truststore.pki.rds.amazonaws.com` via External Secrets (mirroring the existing Cloudflare Authenticated Origin Pulls pattern in `platform`) so the bundle can rotate out-of-band without a chart bump.

### Behavior

When `customCaCertsFromSecret` is empty (default), the `studio-ca-certificates` volume is rendered exactly as before:

```yaml
- name: studio-ca-certificates
  configMap:
    name: studio-ca-certificates
```

When set (e.g. `customCaCertsFromSecret: rds-ca-bundle`), it becomes a `projected` volume combining the chart-managed ConfigMap and the user-managed Secret:

```yaml
- name: studio-ca-certificates
  projected:
    sources:
      - configMap:
          name: studio-ca-certificates
      - secret:
          name: rds-ca-bundle
```

Every key in the Secret's `data:` becomes a file at the mount path, so the consumer Secret should use keys like `rds-ca-bundle.crt` (any name ending in `.crt` so `update-ca-certificates` picks them up; must not collide with the ConfigMap's `self_signed_ca_<N>.crt` keys).

Touches the six pod specs that already mount `studio-ca-certificates`:

- `deployment-studio-backend`
- `deployment-studio-beat`
- `deployment-studio-datachain-api`
- `deployment-studio-datachain-worker`
- `deployment-studio-worker`
- `job-studio-datachain-worker` (the CronJob template)

### Caveats (called out in the values.yaml doc)

- **No auto-rollout on Secret change.** Helm can't checksum a Secret it doesn't render, so the existing `checksum/configmap-ca-cert` pod annotation isn't extended. Use `stakater/reloader` (or accept manual `kubectl rollout restart`) if you need rotations to take effect without intervention. For RDS bundles this is a years-scale event.
- The image must run `update-ca-certificates` at startup, OR the app must point at the file directly (e.g. `DATABASE_OPTIONS` with `sslrootcert=/usr/local/share/ca-certificates/<key>.crt`).

## Verification

- `helm lint charts/studio` ✅
- `helm template` with default values ⇒ volumes identical to `main` (byte-for-byte).
- `helm template --set global.customCaCertsFromSecret=rds-ca-bundle` ⇒ all six pod specs render the projected volume; the volumeMount path (`/usr/local/share/ca-certificates`) is unchanged.

## Test plan

- [ ] CI: `Lint and Test Charts` workflow passes (`ct lint` + `ct install` on kind).
- [ ] CI: `helm-docs` workflow auto-updates `charts/studio/README.md`.
- [ ] Deploy to studio-dev with an `ExternalSecret` populating `rds-ca-bundle` from `https://truststore.pki.rds.amazonaws.com/us-east-2/us-east-2-bundle.pem`, confirm the bundle file appears under `/usr/local/share/ca-certificates/` in a backend pod, and that Postgres connections still succeed.