### PR TITLE
Drop the DataChain install flags from the Studio chart

### DIFF
--- a/charts/studio/Chart.yaml
+++ b/charts/studio/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: studio
 description: A Helm chart for Kubernetes
 type: application
-version: 0.20.11
+version: 0.21.0
 appVersion: "v2.245.0"
 maintainers:
   - name: iterative

--- a/charts/studio/README.md
+++ b/charts/studio/README.md
@@ -1,6 +1,6 @@
 # studio
 
-![Version: 0.20.11](https://img.shields.io/badge/Version-0.20.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.245.0](https://img.shields.io/badge/AppVersion-v2.245.0-informational?style=flat-square)
+![Version: 0.21.0](https://img.shields.io/badge/Version-0.21.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.245.0](https://img.shields.io/badge/AppVersion-v2.245.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/charts/studio/templates/configmap-studio.yaml
+++ b/charts/studio/templates/configmap-studio.yaml
@@ -124,8 +124,3 @@ data:
   {{- else }}
   SOCIAL_AUTH_ALLOWED_REDIRECT_HOSTS: "studio-ui.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.studioUi.service.port }},studio-backend.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.studioBackend.service.port }}"
   {{- end }}
-
-  {{- $datachain := .Values.global.datachain | default dict }}
-  {{- $datachainClickhouse := $datachain.clickHouse | default dict }}
-  DATACHAIN_ENABLED: {{ $datachain.enabled | default false | quote | title }}
-  DATACHAIN_UDF_ENABLED: {{ $datachain.udfEnabled | default false | quote | title }}

--- a/charts/studio/templates/deployment-studio-datachain-worker.yaml
+++ b/charts/studio/templates/deployment-studio-datachain-worker.yaml
@@ -6,11 +6,7 @@ metadata:
     {{- include "studio-datachain-worker.labels" . | nindent 4 }}
 spec:
   {{- if not .Values.studioDatachainWorker.autoscaling.enabled }}
-  {{- if ((.Values.global.datachain).udfEnabled) }}
   replicas: {{ .Values.studioDatachainWorker.replicaCount }}
-  {{- else }}
-  replicas: 0
-  {{- end }}
   {{- end }}
   {{- with .Values.studioDatachainWorker.strategy }}
   strategy:

--- a/charts/studio/templates/hpa-studio-datachain-worker.yaml
+++ b/charts/studio/templates/hpa-studio-datachain-worker.yaml
@@ -13,13 +13,8 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{.Release.Name}}-datachain-worker
-  {{- if ((.Values.global.datachain).udfEnabled) }}
   minReplicas: {{ .Values.studioDatachainWorker.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.studioDatachainWorker.autoscaling.maxReplicas }}
-  {{- else }}
-  minReplicas: 0
-  maxReplicas: 0
-  {{- end}}
   metrics:
     {{- if .Values.studioDatachainWorker.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource


### PR DESCRIPTION
Companion to https://github.com/datachain-ai/studio/pull/13122, itself a follow-up to https://github.com/datachain-ai/studio/pull/13096#issuecomment-5138512887. Being released in parallel.

## The ConfigMap keys

`DATACHAIN_ENABLED` has had no reader since datachain-ai/studio#13096 merged. datachain-ai/studio#13122 removes the last reader of `DATACHAIN_UDF_ENABLED`. Both go, along with the `$datachain` / `$datachainClickhouse` locals that became unused once they did — `secret-studio.yaml` keeps its own copies for `clickHouse.dsn`.

## Why no replacement flag

`global.datachain.udfEnabled` gated **nothing's existence**. It was purely a replica-count override in two spots:

```yaml
# deployment-studio-datachain-worker.yaml   (only inside the non-autoscaling branch)
{{- if ((.Values.global.datachain).udfEnabled) }}
replicas: {{ .Values.studioDatachainWorker.replicaCount }}   # honour the value
{{- else }}
replicas: 0                                                  # override it
{{- end }}
```

The Deployment itself, `configmap-studio-datachain-worker`, the ServiceAccount, Role/RoleBinding, ClusterRole/ClusterRoleBinding, the PVC, the ResourceQuota and the suspended CronJob Job template all rendered regardless. `udfEnabled: false` never meant "no worker component" — it meant "scale the worker to zero".

So there's no replacement knob, because the knob already exists: `studioDatachainWorker.replicaCount` and `studioDatachainWorker.autoscaling.minReplicas` / `maxReplicas` say exactly what `udfEnabled: false` said. `udfEnabled` was a second, chart-global spelling that silently won over the documented per-component values.

A `studioDatachainWorker.enabled` flag would have been wrong twice over — this chart's `enabled` idiom means *render or don't render* (`studioPypiCache.enabled` gates its Deployment/Service/PVC at line 1; `studioBackend.datachainApi.enabled` gates the Service and Ingress backend), which is a strictly bigger hammer than what's being removed, and it would duplicate `replicaCount`.

`global.datachain` itself stays — `clickHouse.dsn` still lives under it.

## ⚠️ Behaviour change

`udfEnabled` defaulted to **false**, so a stock install declared `replicaCount: 1` but rendered `replicas: 0`. It now renders `1`. This deletes an override that contradicted the value it sat on top of.

Anyone who wants no DataChain workers sets `studioDatachainWorker.replicaCount: 0` (or `autoscaling.minReplicas`/`maxReplicas: 0`). Chart minor-bumped to `0.21.0` accordingly.

dev and prod both set `udfEnabled: true` today, so neither environment changes — see the companion platform PR.

## Testing

`helm lint` passes. `helm template` diffed against `main`:

**With the real prod values** (`platform/k8s/prod/studio/studio-values{,-env}.yaml`) — the only non-cosmetic change is the two ConfigMap keys disappearing. No replica or HPA change. Remaining diff is the `helm.sh/chart` label and the ConfigMap/Secret checksum annotations, both expected.

**Stock defaults** — the two ConfigMap keys, plus the intended `replicas: 0` → `replicas: 1`.

**HPA branch**, exercised explicitly since prod doesn't autoscale this worker:

| | old | new |
|---|---|---|
| `autoscaling.enabled=true`, `udfEnabled` unset | `0` / `0` | `1` / `5` |
| `autoscaling.enabled=true`, `udfEnabled=true` | `1` / `5` | `1` / `5` |

i.e. identical wherever `udfEnabled` was set, and honouring the declared values where it wasn't.

https://claude.ai/code/session_01Eb5QaLhxciBiarrZDdJ1ks
